### PR TITLE
Encryption of backups at rest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
 
 install:
-  - "pip install boto mock pep8 psycopg2 pylint pytest python-dateutil python-systemd requests"
+  - "pip install boto cryptography mock pep8 psycopg2 pylint pytest python-dateutil python-systemd requests"
   - "(python -V 2>&1 | grep -qF 'Python 3') || pip install backports.lzma"
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ rpm:
 
 build-dep-fed:
 	sudo yum -y install postgresql-server python-autopep8 \
-		python3-boto python3-dateutil python3-pep8 \
-		python3-psycopg2 python3-pylint python3-pytest \
+		python3-boto python3-cryptography python3-dateutil \
+		python3-pep8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests \
-		python-backports-lzma python-boto python-dateutil python-pep8 \
-		python-psycopg2 pylint pytest python-mock \
-		python-pytest-cov python-requests rpm-build
+		python-backports-lzma python-boto python-cryptography \
+		python-dateutil python-pep8 python-psycopg2 pylint pytest \
+		python-mock python-pytest-cov python-requests rpm-build
 
 test: pep8 pylint unittest
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,11 @@ pg_basebackup that is run against the database in question.
 pghoard compresses the received WAL logs and basebackups with LZMA (level 0)
 in order to ensure good compression speed and relatively small backup size.
 
+Optionally, pghoard can encrypt backed up data at rest. Each individual
+file is encrypted and authenticated with file specific keys. The file
+specific keys are included in the backup in turn encrypted with a master
+RSA private/public key pair.
+
 pghoard also supports backing up and restoring from either a local machine
 or from various object stores (AWS S3, Azure, Ceph, Google Cloud.)
 
@@ -215,6 +220,20 @@ more there are the more diskspace will be used.
 How often to take a new basebackup of a cluster. The shorter the interval,
 the faster your recovery will be, but the more CPU/IO usage is
 required from the servers it takes the basebackup from.
+
+``encryption_key_id`` (no default)
+
+Specifies the encryption key used when storing encrypted backups. If this
+configuration directive is specified, you must also define the public key
+for storing as well as private key for retrieving stored backups. These
+keys are specified with ``encryption_keys`` dictionary.
+
+``encryption_keys`` (no default)
+
+This key is a mapping from key id to keys. Keys in turn are mapping from
+``public`` and ``private`` to PEM encoded RSA public and private keys
+respectively. Public key needs to be specified for storing backups. Private
+key needs to be in place for restoring encrypted backups.
 
 ``http_address`` (default ``""``)
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.1
 Package: pghoard
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
- python-dateutil, python-psycopg2, python-requests
+ python-cryptography, python-dateutil, python-psycopg2, python-requests
 Description: PostgreSQL streaming backup service
  PGhoard is a PostgreSQL streaming backup service allowing the compression
  and encryption of backup files.  Also transfer of backup files to an object

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -15,10 +15,12 @@ Requires(pre):  shadow-utils
 Requires:       postgresql-server, systemd
 BuildRequires:  %{requires}
 %if %{use_python3}
-Requires:       python3-dateutil, python3-psycopg2, python3-requests, python3-boto
-BuildRequires:  python3-pytest, python3-pylint, python3-pep8, %{requires}
+Requires:       python3-boto, python3-cryptography python3-dateutil
+Requires:       python3-psycopg2, python3-requests
+BuildRequires:  python3-pep8, python3-pytest, python3-pylint, %{requires}
 %else
-Requires:       python-dateutil, python-psycopg2, python-requests, python-boto
+Requires:       python-boto, python-cryptography, python-dateutil
+Requires:       python-psycopg2, python-requests
 BuildRequires:  pylint, pytest, python-pep8, %{requires}
 %endif
 BuildArch:      noarch

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -5,12 +5,10 @@ Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 
-from .common import Empty, lzma_compressor, lzma_decompressor, lzma_open
+from .common import Empty, lzma_compressor, lzma_decompressor
 from threading import Thread
-import contextlib
 import logging
 import os
-import shutil
 import time
 
 IO_BLOCK_SIZE = 1 << 20  # 1 MiB
@@ -47,11 +45,19 @@ class Compressor(Thread):
 
     def compress_lzma_filepath(self, filepath, compression_dir):
         lzma_filepath = os.path.join(compression_dir, os.path.basename(filepath)) + ".xz"
-        # NOTE: pyliblzma, which may be in use, is buggy and requires an explicit closing wrapper
-        with contextlib.closing(lzma_open(lzma_filepath, mode="wb", preset=0)) as lzma_file:
-            # TODO: fsync, LZMAFile has no .fileno() on 2.7 etc
-            with open(filepath, "rb") as input_file:
-                shutil.copyfileobj(input_file, lzma_file, length=IO_BLOCK_SIZE)
+        compressor = lzma_compressor(preset=0)
+        with open(filepath, "rb") as input_file:
+            with open(lzma_filepath, "wb") as output_file:
+                while True:
+                    input_data = input_file.read(IO_BLOCK_SIZE)
+                    if not input_data:
+                        break
+                    compressed_data = compressor.compress(input_data)
+                    if compressed_data:
+                        output_file.write(compressed_data)
+                compressed_data = compressor.flush()
+                if compressed_data:
+                    output_file.write(compressed_data)
         return lzma_filepath, "lzma"
 
     def compress_filepath_to_memory(self, filepath):

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -6,6 +6,7 @@ See LICENSE for details
 """
 
 from .common import Empty, lzma_compressor, lzma_decompressor
+from .encryptor import Encryptor, Decryptor
 from threading import Thread
 import logging
 import os
@@ -38,14 +39,17 @@ class Compressor(Thread):
             return filepath.split("/")[-4]
         return filepath.split("/")[-3]
 
-    def compress_filepath(self, filepath, compression_dir):
-        compressed_filepath, algorithm = self.compress_lzma_filepath(filepath, compression_dir)
+    def compress_filepath(self, filepath, compression_dir, rsa_public_key=None):
+        compressed_filepath, algorithm = self.compress_lzma_filepath(filepath, compression_dir, rsa_public_key)
         compressed_file_size = os.stat(compressed_filepath).st_size
         return compressed_filepath, algorithm, compressed_file_size
 
-    def compress_lzma_filepath(self, filepath, compression_dir):
+    def compress_lzma_filepath(self, filepath, compression_dir, rsa_public_key=None):
         lzma_filepath = os.path.join(compression_dir, os.path.basename(filepath)) + ".xz"
         compressor = lzma_compressor(preset=0)
+        encryptor = None
+        if rsa_public_key:
+            encryptor = Encryptor(rsa_public_key)
         with open(filepath, "rb") as input_file:
             with open(lzma_filepath, "wb") as output_file:
                 while True:
@@ -53,19 +57,25 @@ class Compressor(Thread):
                     if not input_data:
                         break
                     compressed_data = compressor.compress(input_data)
+                    if encryptor and compressed_data:
+                        compressed_data = encryptor.update(compressed_data)
                     if compressed_data:
                         output_file.write(compressed_data)
                 compressed_data = compressor.flush()
+                if encryptor:
+                    if compressed_data:
+                        compressed_data = encryptor.update(compressed_data)
+                    compressed_data += encryptor.finalize()
                 if compressed_data:
                     output_file.write(compressed_data)
         return lzma_filepath, "lzma"
 
-    def compress_filepath_to_memory(self, filepath):
-        compressed_data, algorithm, compressed_file_size = self.compress_lzma_filepath_to_memory(filepath)
+    def compress_filepath_to_memory(self, filepath, rsa_public_key=None):
+        compressed_data, algorithm, compressed_file_size = self.compress_lzma_filepath_to_memory(filepath, rsa_public_key)
         compressed_file_size = len(compressed_data)
         return compressed_data, algorithm, compressed_file_size
 
-    def compress_lzma_filepath_to_memory(self, filepath):
+    def compress_lzma_filepath_to_memory(self, filepath, rsa_public_key=None):
         # This is meant for WAL files compressed due to archive_command
         with open(filepath, "rb") as input_file:
             data = input_file.read()
@@ -73,6 +83,9 @@ class Compressor(Thread):
         compressor = lzma_compressor(preset=0)
         compressed_data = compressor.compress(data)
         compressed_data += compressor.flush()
+        if rsa_public_key:
+            encryptor = Encryptor(rsa_public_key)
+            compressed_data = encryptor.update(compressed_data) + encryptor.finalize()
         return compressed_data, "lzma", len(compressed_data)
 
     def run(self):
@@ -120,8 +133,13 @@ class Compressor(Thread):
     def handle_decompression_event(self, event):
         start_time = time.time()
         decompressor = lzma_decompressor()
-        with open(event['local_path'], "wb") as fp:
-            data = decompressor.decompress(event['blob'])
+        data = event["blob"]
+        if 'metadata' in event and 'encryption_key_id' in event['metadata']:
+            rsa_private_key = self.config['backup_sites'][event['site']]['encryption_keys'][event['metadata']['encryption_key_id']]['private']
+            decryptor = Decryptor(rsa_private_key)
+            data = decryptor.update(data) + decryptor.finalize()
+        data = decompressor.decompress(data)
+        with open(event['local_path'], 'wb') as fp:
             fp.write(data)
 
         self.log.debug("Decompressed %d byte file: %r to %d bytes, took: %.3fs",
@@ -134,16 +152,20 @@ class Compressor(Thread):
     def handle_event(self, event, filetype):
         start_time, compressed_blob = time.time(), None
         site = event.get("site", self.find_site_for_file(event['full_path']))
+        rsa_public_key = None
+        encryption_key_id = self.config['backup_sites'][site].get('encryption_key_id', None)
+        if encryption_key_id:
+            rsa_public_key = self.config['backup_sites'][site]['encryption_keys'][encryption_key_id]['public']
 
         original_file_size = os.stat(event['full_path']).st_size
         self.log.debug("Starting to compress: %r, filetype: %r, original_size: %r",
                        event['full_path'], filetype, original_file_size)
         if event.get("compress_to_memory", False):
-            compressed_blob, compression_algorithm, compressed_file_size = self.compress_filepath_to_memory(event['full_path'])
-
+            compressed_blob, compression_algorithm, compressed_file_size = self.compress_filepath_to_memory(event['full_path'], rsa_public_key)
         else:
             compressed_filepath, compression_algorithm, compressed_file_size = self.compress_filepath(event['full_path'],
-                                                                                                      self.get_compressed_file_path(site, filetype, os.path.dirname(event['full_path'])))
+                                                                                                      self.get_compressed_file_path(site, filetype, os.path.dirname(event['full_path'])),
+                                                                                                      rsa_public_key)
         self.log.info("Compressed %d byte file: %r to %d bytes, took: %.3fs",
                       original_file_size, event['full_path'], compressed_file_size,
                       time.time() - start_time)
@@ -154,6 +176,8 @@ class Compressor(Thread):
         metadata = {'compression-algorithm': compression_algorithm, 'original-file-size': original_file_size}
         if 'start-wal-segment' in event:
             metadata['start-wal-segment'] = event['start-wal-segment']
+        if encryption_key_id:
+            metadata['encryption_key_id'] = encryption_key_id
 
         self.set_state_defaults_for_site(site)
         self.state[site][filetype]["original_data"] += original_file_size

--- a/pghoard/encryptor.py
+++ b/pghoard/encryptor.py
@@ -1,0 +1,111 @@
+"""
+pghoard - content encryption
+
+Copyright (c) 2015 Ohmu Ltd
+See LICENSE for details
+"""
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.hashes import SHA1, SHA256
+from cryptography.hazmat.primitives.hmac import HMAC
+from cryptography.hazmat.primitives import serialization
+import os
+import struct
+
+FILEMAGIC = b"pghoa1"
+
+
+class EncryptorError(Exception):
+    """ EncryptorError """
+
+
+class Encryptor(object):
+    def __init__(self, rsa_public_key_pem):
+        self.rsa_public_key = serialization.load_pem_public_key(rsa_public_key_pem, backend=default_backend())
+        self.cipher = None
+        self.authenticator = None
+
+    def update(self, data):
+        ret = b""
+        if self.cipher is None:
+            key = os.urandom(16)
+            nonce = os.urandom(16)
+            auth_key = os.urandom(32)
+            self.cipher = Cipher(algorithms.AES(key), modes.CTR(nonce), backend=default_backend()).encryptor()
+            self.authenticator = HMAC(auth_key, SHA256(), backend=default_backend())
+            pad = padding.OAEP(mgf=padding.MGF1(algorithm=SHA1()),
+                               algorithm=SHA1(),
+                               label=None)
+            cipherkey = self.rsa_public_key.encrypt(key + nonce + auth_key, pad)
+            ret = FILEMAGIC + struct.pack(">H", len(cipherkey)) + cipherkey
+        cur = self.cipher.update(data)
+        self.authenticator.update(cur)
+        ret += cur
+        return ret
+
+    def finalize(self):
+        if self.cipher is None:
+            raise EncryptorError("Invalid state")
+        ret = self.cipher.finalize()
+        self.authenticator.update(ret)
+        ret += self.authenticator.finalize()
+        self.cipher = None
+        self.authenticator = None
+        return ret
+
+
+class Decryptor(object):
+    def __init__(self, rsa_private_key_pem):
+        self.rsa_private_key = serialization.load_pem_private_key(rsa_private_key_pem, password=None, backend=default_backend())
+        self.cipher = None
+        self.authenticator = None
+        self.buf = b""
+
+    def update(self, data):
+        self.buf += data
+        if self.cipher is None:
+            if len(self.buf) < 8:
+                return b""
+            if self.buf[0:6] != FILEMAGIC:
+                raise EncryptorError("Invalid magic bytes")
+            cipherkeylen = struct.unpack(">H", self.buf[6:8])[0]
+            if len(self.buf) < 8 + cipherkeylen:
+                return b""
+            pad = padding.OAEP(mgf=padding.MGF1(algorithm=SHA1()),
+                               algorithm=SHA1(),
+                               label=None)
+            try:
+                plainkey = self.rsa_private_key.decrypt(self.buf[8:8 + cipherkeylen], pad)
+            except AssertionError:
+                raise EncryptorError("Decrypting key data failed")
+            if len(plainkey) != 64:
+                raise EncryptorError("Integrity check failed")
+            key = plainkey[0:16]
+            nonce = plainkey[16:32]
+            auth_key = plainkey[32:64]
+
+            self.cipher = Cipher(algorithms.AES(key), modes.CTR(nonce), backend=default_backend()).decryptor()
+            self.authenticator = HMAC(auth_key, SHA256(), backend=default_backend())
+            self.buf = self.buf[8 + cipherkeylen:]
+
+        if len(self.buf) < 32:
+            return b""
+
+        self.authenticator.update(self.buf[:-32])
+        result = self.cipher.update(self.buf[:-32])
+        self.buf = self.buf[-32:]
+
+        return result
+
+    def finalize(self):
+        if self.cipher is None:
+            raise EncryptorError("Invalid state")
+        if self.buf != self.authenticator.finalize():
+            raise EncryptorError("Integrity check failed")
+        result = self.cipher.finalize()
+        self.buf = b""
+        self.cipher = None
+        self.authenticator = None
+        return result

--- a/pghoard/object_storage/__init__.py
+++ b/pghoard/object_storage/__init__.py
@@ -100,7 +100,8 @@ class TransferAgent(Thread):
             # Note that here we flip the local_path to mean the target_path
             self.compression_queue.put({"type": "decompression", "blob": content, "metadata": metadata,
                                         "callback_queue": file_to_transfer["callback_queue"],
-                                        "local_path": file_to_transfer["target_path"]})
+                                        "local_path": file_to_transfer["target_path"],
+                                        "site": site})
             self.state[site]["download"][filetype]["data"] += file_to_transfer["file_size"]
             self.state[site]["download"][filetype]["count"] += 1
             self.state[site]["download"][filetype]["time_taken"] += time.time() - start_time

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -16,6 +16,32 @@ import tempfile
 format_str = "%(asctime)s\t%(name)s\t%(threadName)s\t%(levelname)s\t%(message)s"
 logging.basicConfig(level=logging.DEBUG, format=format_str)
 
+TEST_RSA_PUB = b"""\
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQ9yu7rNmu0GFMYeQq9Jo2B3d9
+hv5t4a+54TbbxpJlks8T27ipgsaIjqiQP7+uXNfU6UCzGFEHs9R5OELtO3Hq0Dn+
+JGdxJlJ1prxVkvjCICCpiOkhc2ytmn3PWRuVf2VyeAddslEWHuXhZPptvIr593kF
+lWN+9KPe+5bXS8of+wIDAQAB
+-----END PUBLIC KEY-----"""
+
+TEST_RSA_PRV = b"""\
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAND3K7us2a7QYUxh
+5Cr0mjYHd32G/m3hr7nhNtvGkmWSzxPbuKmCxoiOqJA/v65c19TpQLMYUQez1Hk4
+Qu07cerQOf4kZ3EmUnWmvFWS+MIgIKmI6SFzbK2afc9ZG5V/ZXJ4B12yURYe5eFk
++m28ivn3eQWVY370o977ltdLyh/7AgMBAAECgYEAkuAobRFhL+5ndTiZF1g1zCQT
+aLepvbITwaL63B8GZz55LowRj5PL18/tyvYD1JqNWalZQIim67MKdOmGoRhXSF22
+gUc6/SeqD27/9rsj8I+j0TrzLdTZwn88oX/gtndNutZuryCC/7KbJ8j18Jjn5qf9
+ZboRKbEc7udxOb+RcYECQQD/ZLkxIvMSj0TxPUJcW4MTEsdeJHCSnQAhreIf2omi
+hf4YwmuU3qnFA3ROje9jJe3LNtc0TK1kvAqfZwdpqyAdAkEA0XY4P1CPqycYvTxa
+dxxWJnYA8K3g8Gs/Eo8wYKIciP+K70Q0GRP9Qlluk4vrA/wJJnTKCUl7YuAX6jDf
+WdV09wJALGHXoQde0IHfTEEGEEDC9YSU6vJQMdpg1HmAS2LR+lFox+q5gWR0gk1I
+YAJgcI191ovQOEF+/HuFKRBhhGZ9rQJAXOt13liNs15/sgshEq/mY997YUmxfNYG
+v+P3kRa5U+kRKD14YxukARgNXrT2R+k54e5zZhVMADvrP//4RTDVVwJBAN5TV9p1
+UPZXbydO8vZgPuo001KoEd9N3inq/yNcsHoF/h23Sdt/rcdfLMpCWuIYs/JAqE5K
+nkMAHqg9PS372Cs=
+-----END PRIVATE KEY-----"""
+
 
 class TestCompression(TestCase):
     def setUp(self):
@@ -24,6 +50,12 @@ class TestCompression(TestCase):
             "backup_sites": {
                 "default": {
                     "object_storage": {"s3": {}},
+                    "encryption_keys": {
+                        "testkey": {
+                            "public": TEST_RSA_PUB,
+                            "private": TEST_RSA_PRV
+                        }
+                    }
                 },
             },
             "backup_location": self.temp_dir,
@@ -75,6 +107,18 @@ class TestCompression(TestCase):
             assert transfer_event[key] == value
         assert lzma.decompress(transfer_event["blob"]) == b"foo"
 
+    def test_compress_encrypt_to_memory(self):
+        self.compressor.config['backup_sites']['default']['encryption_key_id'] = 'testkey'
+        event = {'type': 'MOVE', 'src_path': self.foo_path_partial,
+                 'full_path': self.foo_path, 'delete_file_after_compression': False,
+                 'compress_to_memory': True}
+        self.compressor.handle_event(event, filetype='xlog')
+        expected = {'filetype': 'xlog', 'site': 'default', 'local_path': self.foo_path, 'callback_queue': None,
+                    'metadata': {'compression-algorithm': 'lzma', 'original-file-size': 3, 'encryption_key_id': 'testkey'}}
+        transfer_event = self.transfer_queue.get()
+        for key, value in expected.items():
+            assert transfer_event[key] == value
+
     def test_archive_command_compression(self):
         callback_queue = Queue()
         event = {"type": "CREATE", "src_path": self.foo_path_partial,
@@ -95,11 +139,28 @@ class TestCompression(TestCase):
                                     "filetype": "xlog",
                                     "blob": lzma.compress(b"foo"),
                                     "callback_queue": callback_queue,
-                                    "type": "decompression"})
+                                    "type": "decompression",
+                                    "site": "default"})
         callback_queue.get(timeout=1.0)
         self.assertTrue(os.path.exists(local_filepath))
         with open(local_filepath, "rb") as fp:
             assert fp.read() == b"foo"
+
+    def test_decompression_decrypt_event(self):
+        blob, _, _ = self.compressor.compress_lzma_filepath_to_memory(self.foo_path, TEST_RSA_PUB)
+        callback_queue = Queue()
+        local_filepath = os.path.join(self.temp_dir, '00000001000000000000000E')
+        self.compression_queue.put({'local_path': local_filepath,
+                                    'filetype': 'xlog',
+                                    'blob': blob,
+                                    'callback_queue': callback_queue,
+                                    'type': 'decompression',
+                                    'site': 'default',
+                                    'metadata': {'encryption_key_id': 'testkey'}})
+        callback_queue.get(timeout=1.0)
+        self.assertTrue(os.path.exists(local_filepath))
+        with open(local_filepath, 'rb') as fp:
+            assert fp.read() == b'foo'
 
     def tearDown(self):
         self.compressor.running = False

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -61,7 +61,7 @@ class TestTransferAgent(TestCase):
         self.transfer_queue.put({"local_path": self.temp_dir, "filetype": "xlog", "site": "default",
                                  "callback_queue": callback_queue, "operation": "download", "target_path": self.temp_dir})
         self.assertEqual(self.compression_queue.get(timeout=1.0), {'blob': b'joo', 'metadata': {'key': 'value'}, 'type': 'decompression',
-                                                                   "callback_queue": callback_queue, "local_path": self.temp_dir})
+                                                                   'callback_queue': callback_queue, 'local_path': self.temp_dir, 'site': 'default'})
 
     def test_handle_upload_xlog(self):
         callback_queue = Queue()


### PR DESCRIPTION
Support for encrypting backups at rest. RSA keys are used as master keys: public side of the pair is configured where backups are generated. Private key can be injected on the nodes performing restore or at the time of restore.

As for the individual files and blobs, each is encrypted with an single-use generated random key; the key material is encrypted with RSA and prepended to the actual contents.

MAC is appended to the end of the file. This allows streaming of the outflowing data, but only allows rejecting a downloaded content once the full content is fetched and availble.

The cipher code is now injected into the compressor module. I would explore whether both compression and encryption could be implemented as independent but stackable "filters" if you will.