### PR TITLE
restore: make primary_conninfo optional

### DIFF
--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -1,0 +1,32 @@
+"""
+pghoard
+
+Copyright (c) 2015 Ohmu Ltd
+See LICENSE for details
+"""
+
+from pghoard.restore import create_recovery_conf
+from tempfile import mkdtemp
+from shutil import rmtree
+import os
+
+
+def test_create_recovery_conf():
+    td = mkdtemp(prefix="pghoardtest.")
+    try:
+        fn = os.path.join(td, "recovery.conf")
+
+        def getdata():
+            with open(fn, "r") as fp:
+                return fp.read()
+
+        assert not os.path.exists(fn)
+        create_recovery_conf(td, "dummysite", None)
+        assert "primary_conninfo" not in getdata()
+        create_recovery_conf(td, "dummysite", "")
+        assert "primary_conninfo" not in getdata()
+        create_recovery_conf(td, "dummysite", "dbname='test'")
+        assert "primary_conninfo" in getdata()  # make sure it's there
+        assert "''test''" in getdata()  # make sure it's quoted
+    finally:
+        rmtree(td)


### PR DESCRIPTION
PostgreSQL doesn't require primary_conninfo in recovery.conf if
restore_command is given.  We did not require it in pghoard's restore but
always wrote a line for it (with empty value) if it wasn't given.
PostgreSQL doesn't like that so stop doing it.