### PR TITLE
pghoard: when running quit(), also stop any running basebackup processes

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -66,8 +66,9 @@ class PGBaseBackup(Thread):
         self.log.debug("Ran: %r, took: %.3fs to run, returncode: %r", self.command, time.time() - start_time,
                        proc.returncode)
         basebackup_path = os.path.join(self.basebackup_location, "base.tar")
-        start_wal_segment = self.parse_backup_label(basebackup_path)
-        self.set_basebackup_metadata(self.basebackup_location, {"start-wal-segment": start_wal_segment})
-        self.compression_queue.put({"type": "CREATE", "full_path": basebackup_path,
-                                    "start-wal-segment": start_wal_segment})
+        if os.path.exists(basebackup_path):
+            start_wal_segment = self.parse_backup_label(basebackup_path)
+            self.set_basebackup_metadata(self.basebackup_location, {"start-wal-segment": start_wal_segment})
+            self.compression_queue.put({"type": "CREATE", "full_path": basebackup_path,
+                                        "start-wal-segment": start_wal_segment})
         self.running = False

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -419,6 +419,8 @@ class PGHoard(object):
         self.log.warning("Quitting, signal: %r, frame: %r", _signal, _frame)
         self.running = False
         self.inotify.running = False
+        for basebackup in self.basebackups.values():
+            basebackup.running = False
         for receivexlog in self.receivexlogs.values():
             receivexlog.running = False
         for compressor in self.compressors:


### PR DESCRIPTION
Also in basebackup, make sure we actually have the basebackup tar
before trying to parse it.