### PR TITLE
restore: don't print tracebacks when file doesn't exist in s3

### DIFF
--- a/pghoard/errors.py
+++ b/pghoard/errors.py
@@ -16,3 +16,7 @@ class InvalidConfigurationError(Error):
 
 class StorageError(Error):
     """storage exception"""
+
+
+class FileNotFoundFromStorageError(StorageError):
+    """file not found from remote storage"""


### PR DESCRIPTION
Restore used to print out large and scary looking tracebacks when a file was
missing from storage.  Downgrade file not found errors in S3 (and other
object stores later on) to warnings as it's expected that restore ends in
the "last" file missing.