### PR TITLE
restore: remove object store specific commands and use a config

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -7,33 +7,19 @@ See LICENSE for details
 from __future__ import print_function
 from .common import lzma_decompressor, lzma_open_read, default_log_format_str
 from .errors import Error
+from .object_storage import get_object_storage_transfer
 from psycopg2.extensions import adapt
 from requests import Session
 import argparse
 import datetime
+import json
 import logging
 import os
 import random
 import shutil
-import socket
 import sys
 import tarfile
 import time
-
-try:
-    from . object_storage import google as google_storage
-except ImportError as ex:
-    google_storage = ex
-
-try:
-    from . object_storage import azure as azure_storage
-except ImportError as ex:
-    azure_storage = ex
-
-try:
-    from . object_storage import s3 as s3_storage
-except ImportError as ex:
-    s3_storage = ex
 
 
 class RestoreError(Exception):
@@ -92,16 +78,13 @@ class Restore(object):
         parser = argparse.ArgumentParser()
         sub = parser.add_subparsers(help="sub-command help")
 
-        def host_port_site_args():
+        def generic_args():
+            cmd.add_argument("--site", help="pghoard site", required=True)
+            cmd.add_argument("--config", help="pghoard config file", required=True)
+
+        def host_port_args():
             cmd.add_argument("--host", help="pghoard repository host", default="localhost")
             cmd.add_argument("--port", help="pghoard repository port", default=16000)
-            cmd.add_argument("--site", help="pghoard site", default="default")
-
-        cmd = self.add_cmd(sub, self.get)
-        cmd.add_argument("filename", help="filename to retrieve")
-        cmd.add_argument("target_path", help="local target filename")
-        host_port_site_args()
-        cmd.add_argument("--path-prefix", help="path_prefix (useful for testing)")
 
         def target_args():
             cmd.add_argument("--basebackup", help="pghoard basebackup", default="latest")
@@ -110,136 +93,56 @@ class Restore(object):
             cmd.add_argument("--overwrite", help="overwrite existing target directory",
                              default=False, action="store_true")
 
-        def azure_args():
-            cmd.add_argument("--account", help="Azure storage account name [AZURE_STORAGE_ACCOUNT]",
-                             default=os.environ.get("AZURE_STORAGE_ACCOUNT"))
-            cmd.add_argument("--access-key", help="Azure storage access key [AZURE_STORAGE_ACCESS_KEY]",
-                             default=os.environ.get("AZURE_STORAGE_ACCESS_KEY"))
-            cmd.add_argument("--container", help="Azure container name", default="pghoard")
-            cmd.add_argument("--site", help="pghoard site", default="default")
-
-        cmd = self.add_cmd(sub, self.get_basebackup_azure, precondition=azure_storage)
-        azure_args()
-        target_args()
-
-        cmd = self.add_cmd(sub, self.list_basebackups_azure, precondition=azure_storage)
-        azure_args()
-
-        def google_args():
-            cmd.add_argument("--project-id", help="Google Cloud project ID", required=True)
-            cmd.add_argument("--credentials-file", metavar="FILE", help="Google credential file path [GOOGLE_APPLICATION_CREDENTIALS]",
-                             default=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
-            cmd.add_argument("--bucket", help="Google Cloud container name", default="pghoard")
-            cmd.add_argument("--site", help="pghoard site", default="default")
-
-        cmd = self.add_cmd(sub, self.get_basebackup_google, precondition=google_storage)
-        google_args()
-        target_args()
-
-        cmd = self.add_cmd(sub, self.list_basebackups_google, precondition=google_storage)
-        google_args()
-
         cmd = self.add_cmd(sub, self.get_basebackup_http)
-        host_port_site_args()
+        cmd.add_argument("filename", help="filename to retrieve")
+        cmd.add_argument("target_path", help="local target filename")
         target_args()
+        host_port_args()
+        generic_args()
+        cmd.add_argument("--path-prefix", help="path_prefix (useful for testing)")
 
         cmd = self.add_cmd(sub, self.list_basebackups_http)
-        host_port_site_args()
+        host_port_args()
+        generic_args()
 
-        def aws_args():
-            cmd.add_argument("--aws-access-key-id", help="AWS Access Key ID [AWS_ACCESS_KEY_ID]", default=os.environ.get("AWS_ACCESS_KEY_ID"))
-            cmd.add_argument("--aws-secret-access-key", help="AWS Secret Access Key [AWS_SECRET_ACCESS_KEY]", default=os.environ.get("AWS_SECRET_ACCESS_KEY"))
-            cmd.add_argument("--region", help="AWS S3 region", default="eu-west-1")
-            cmd.add_argument("--bucket", help="AWS S3 bucket name", required=True)
-            cmd.add_argument("--site", help="pghoard site", default="default")
-            cmd.add_argument("--host", help="S3 host address (non-AWS S3 implementations)")
-            cmd.add_argument("--port", help="S3 port (non-AWS S3 implementations)", default=9090, type=int)
-            cmd.add_argument("--insecure", help="Use plaintext HTTP (non-AWS S3 implementations)", action="store_true", default=False)
-
-        cmd = self.add_cmd(sub, self.get_basebackup_s3, precondition=s3_storage)
-        aws_args()
+        cmd = self.add_cmd(sub, self.list_basebackups)
+        generic_args()
+        cmd = self.add_cmd(sub, self.get_basebackup)
         target_args()
-
-        cmd = self.add_cmd(sub, self.list_basebackups_s3, precondition=s3_storage)
-        aws_args()
-
+        generic_args()
         return parser
 
-    def get(self, arg):
-        """Download a basebackup archive from a HTTP server"""
-        self.storage = HTTPRestore(arg.host, arg.port, arg.site)
-        if not self.storage.get_archive_file(arg.filename, arg.target_path, arg.path_prefix):
-            return 1
-
-    def get_basebackup_azure(self, arg):
-        """Download a basebackup from Microsoft Azure"""
-        try:
-            self.storage = AzureRestore(arg.account, arg.access_key, arg.container, pgdata=arg.target_dir, site=arg.site)
-            self.get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
-        except socket.gaierror as ex:
-            raise RestoreError("{}: {} (wrong account name?)".format(ex.__class__.__name__, ex))
-        except (Error, azure_storage.WindowsAzureError) as ex:
-            raise RestoreError("{}: {!r}".format(ex.__class__.__name__, ex))
-
-    def list_basebackups_azure(self, arg):
-        """List available basebackups from Microsoft Azure"""
-        try:
-            self.storage = AzureRestore(arg.account, arg.access_key, arg.container, arg.site)
-            self.storage.show_basebackup_list()
-        except socket.gaierror as ex:
-            raise RestoreError("{}: {} (wrong account name?)".format(ex.__class__.__name__, ex))
-        except (Error, azure_storage.WindowsAzureError) as ex:
-            raise RestoreError("{}: {!r}".format(ex.__class__.__name__, ex))
-
-    def get_basebackup_google(self, arg):
-        """Download a basebackup from Google Cloud"""
-        try:
-            self.storage = GoogleRestore(arg.project_id, arg.credentials_file, arg.bucket, pgdata=arg.target_dir, site=arg.site)
-            self.get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
-        except google_storage.OAuth2Error as ex:
-            raise RestoreError("{}: {} (invalid GOOGLE_APPLICATION_CREDENTIALS file?)".format(ex.__class__.__name__, ex))
-        except (Error, google_storage.HttpError) as ex:
-            raise RestoreError("{}: {}".format(ex.__class__.__name__, ex))
-
-    def list_basebackups_google(self, arg):
-        """List available basebackups from Google Cloud"""
-        try:
-            self.storage = GoogleRestore(arg.project_id, arg.credentials_file, arg.bucket, site=arg.site)
-            self.storage.show_basebackup_list()
-        except google_storage.OAuth2Error as ex:
-            raise RestoreError("{}: {} (invalid GOOGLE_APPLICATION_CREDENTIALS file?)".format(ex.__class__.__name__, ex))
-        except (Error, google_storage.HttpError) as ex:
-            raise RestoreError("{}: {}".format(ex.__class__.__name__, ex))
-
     def get_basebackup_http(self, arg):
-        """Download a basebackup from Google Cloud"""
+        """Download a basebackup from a HTTP source"""
         self.storage = HTTPRestore(arg.host, arg.port, arg.site, arg.target_dir)
-        self.get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
+        self._get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
 
     def list_basebackups_http(self, arg):
         """List available basebackups from a HTTP source"""
         self.storage = HTTPRestore(arg.host, arg.port, arg.site)
         self.storage.show_basebackup_list()
 
-    def get_basebackup_s3(self, arg):
-        """Download a basebackup from S3"""
+    def _get_object_storage(self, config, site, pgdata):
+        with open(config) as fp:
+            config = json.load(fp)
+        ob = config["backup_sites"][site]["object_storage"]
+        storage = get_object_storage_transfer(list(ob.keys())[0], list(ob.values())[0])
+        return ObjectStore(storage, site, pgdata)
+
+    def list_basebackups(self, arg):
+        """List basebackups from an object store"""
+        self.storage = self._get_object_storage(arg.config, arg.site, pgdata=None)
+        self.storage.show_basebackup_list()
+
+    def get_basebackup(self, arg):
+        """Download a basebackup from an object store"""
         try:
-            self.storage = S3Restore(arg.aws_access_key_id, arg.aws_secret_access_key, arg.region, arg.bucket, arg.site,
-                                     host=arg.host, port=arg.port, is_secure=(not arg.insecure), pgdata=arg.target_dir)
-            self.get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
-        except (Error, s3_storage.boto.exception.BotoServerError) as ex:
+            self.storage = self._get_object_storage(arg.config, arg.site, arg.target_dir)
+            self._get_basebackup(arg.target_dir, arg.basebackup, arg.site, arg.primary_conninfo, overwrite=arg.overwrite)
+        except Exception as ex:
             raise RestoreError("{}: {}".format(ex.__class__.__name__, ex))
 
-    def list_basebackups_s3(self, arg):
-        """List available basebackups from S3"""
-        try:
-            self.storage = S3Restore(arg.aws_access_key_id, arg.aws_secret_access_key, arg.region, arg.bucket, arg.site,
-                                     host=arg.host, port=arg.port, is_secure=(not arg.insecure), pgdata=None)
-            self.storage.show_basebackup_list()
-        except (Error, s3_storage.boto.exception.BotoServerError) as ex:
-            raise RestoreError("{}: {}".format(ex.__class__.__name__, ex))
-
-    def get_basebackup(self, pgdata, basebackup, site, primary_conninfo, overwrite=False):
+    def _get_basebackup(self, pgdata, basebackup, site, primary_conninfo, overwrite=False):
         #  If basebackup that we want it set as latest, figure out which one it is
         if basebackup == "latest":
             basebackups = self.storage.list_basebackups()  # pylint: disable=protected-access
@@ -310,24 +213,6 @@ class ObjectStore(object):
         self.storage.get_contents_to_file(basebackup, basebackup_path)
         tar = tarfile.TarFile(fileobj=lzma_open_read(basebackup_path, "rb"))
         return metadata["start-wal-segment"], basebackup_path, tar
-
-
-class AzureRestore(ObjectStore):
-    def __init__(self, account_name, account_key, container, site, pgdata=None):
-        storage = azure_storage.AzureTransfer(account_name, account_key, container)
-        ObjectStore.__init__(self, storage, site, pgdata)
-
-
-class GoogleRestore(ObjectStore):
-    def __init__(self, project_id, credential_file, bucket, site, pgdata=None):
-        storage = google_storage.GoogleTransfer(project_id=project_id, bucket_name=bucket, credential_file=credential_file)
-        ObjectStore.__init__(self, storage, site, pgdata)
-
-
-class S3Restore(ObjectStore):
-    def __init__(self, aws_access_key_id, aws_secret_access_key, region, bucket_name, site, host=None, port=None, is_secure=None, pgdata=None):
-        storage = s3_storage.S3Transfer(aws_access_key_id, aws_secret_access_key, region, bucket_name, host=host, port=port, is_secure=is_secure)
-        ObjectStore.__init__(self, storage, site, pgdata)
 
 
 class HTTPRestore(object):


### PR DESCRIPTION
The rationale behind this is to simplify the code and to allow direct
use of the configuration file. This will help in upcoming features
like adding of encryption/decryption for WAL and basebackups.