### PR TITLE
webserver: fix metadata handling on local WAL restore

### DIFF
--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -112,14 +112,14 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             metadata = {}
             archived_file_path = os.path.join(self.server.config['backup_location'], site, "compressed_%s" % filetype, filename + ".xz")
-            metadata_path = os.path.join(self.server.config['backup_location'], site, "compressed_%s" % filetype, filename + ".metadata")
+            metadata_path = archived_file_path + ".metadata"
             if os.path.exists(metadata_path):
                 with open(metadata_path, "r") as fp:
                     metadata = json.load(fp)
             if os.path.exists(archived_file_path):
                 with open(archived_file_path, "rb") as source_fp:
                     with open(target_path, "wb") as target_fp:
-                        if metadata.get("compression_algorithm") == "lzma":
+                        if metadata.get("compression-algorithm") == "lzma":
                             source_fp = lzma_open_read(source_fp, "r")
                         while True:
                             data = source_fp.read(IO_BLOCK_SIZE)

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -80,7 +80,7 @@ class TestTransferAgent(PGHoardTestCase):
             "file_size": 3,
             "filetype": "xlog",
             "local_path": self.foo_path,
-            "metadata": {"start-wal-segment": "00000001000000000000000C", "compression_algorithm": "lzma"},
+            "metadata": {"start-wal-segment": "00000001000000000000000C"},
             "site": "default",
             "type": "UPLOAD",
         })
@@ -97,7 +97,7 @@ class TestTransferAgent(PGHoardTestCase):
             "file_size": 3,
             "filetype": "basebackup",
             "local_path": self.foo_basebackup_path,
-            "metadata": {"start-wal-segment": "00000001000000000000000C", "compression_algorithm": "lzma"},
+            "metadata": {"start-wal-segment": "00000001000000000000000C"},
             "site": "default",
             "type": "UPLOAD",
         })


### PR DESCRIPTION
Decompress on metadata change had a bug on metadata handling in WAL restore from local directory. This change 1) reads the metadata from the correct location and 2) uses a correct metadata key for compression.

A test is updated to verify the data is handled correctly.