### PR TITLE
two small fixes

### DIFF
--- a/pghoard/encryptor.py
+++ b/pghoard/encryptor.py
@@ -25,6 +25,8 @@ class EncryptorError(Exception):
 
 class Encryptor(object):
     def __init__(self, rsa_public_key_pem):
+        if isinstance(rsa_public_key_pem, str):
+            rsa_public_key_pem = rsa_public_key_pem.encode("utf-8")
         self.rsa_public_key = serialization.load_pem_public_key(rsa_public_key_pem, backend=default_backend())
         self.cipher = None
         self.authenticator = None
@@ -60,6 +62,8 @@ class Encryptor(object):
 
 class Decryptor(object):
     def __init__(self, rsa_private_key_pem):
+        if isinstance(rsa_private_key_pem, str):
+            rsa_private_key_pem = rsa_private_key_pem.encode("utf-8")
         self.rsa_private_key = serialization.load_pem_private_key(rsa_private_key_pem, password=None, backend=default_backend())
         self.cipher = None
         self.authenticator = None

--- a/pghoard/object_storage/s3.py
+++ b/pghoard/object_storage/s3.py
@@ -7,6 +7,7 @@ See LICENSE for details
 import boto.exception
 import boto.s3
 import dateutil.parser
+from boto.s3.connection import OrdinaryCallingFormat
 from boto.s3.key import Key
 from pghoard.errors import FileNotFoundFromStorageError, InvalidConfigurationError
 from .base import BaseTransfer
@@ -32,7 +33,7 @@ class S3Transfer(BaseTransfer):
             self.conn = boto.connect_s3(aws_access_key_id=aws_access_key_id,
                                         aws_secret_access_key=aws_secret_access_key,
                                         host=host, port=port, is_secure=is_secure,
-                                        calling_format=boto.s3.connection.OrdinaryCallingFormat())
+                                        calling_format=OrdinaryCallingFormat())
         else:
             self.conn = boto.s3.connect_to_region(region_name=region, aws_access_key_id=aws_access_key_id,
                                                   aws_secret_access_key=aws_secret_access_key)


### PR DESCRIPTION
Accept encryption keys as both str and bytes. The latter is expected by the cryptography library but the former tends to be the format how stuff is passed around in configuration files.

The second fix is an symbol import fix for non-AWS but S3 compatible object storages.