### PR TITLE
encryptor: implement seek in DecryptorFile

### DIFF
--- a/pghoard/encryptor.py
+++ b/pghoard/encryptor.py
@@ -25,8 +25,8 @@ class EncryptorError(Exception):
 
 class Encryptor(object):
     def __init__(self, rsa_public_key_pem):
-        if isinstance(rsa_public_key_pem, str):
-            rsa_public_key_pem = rsa_public_key_pem.encode("utf-8")
+        if not isinstance(rsa_public_key_pem, bytes):
+            rsa_public_key_pem = rsa_public_key_pem.encode("ascii")
         self.rsa_public_key = serialization.load_pem_public_key(rsa_public_key_pem, backend=default_backend())
         self.cipher = None
         self.authenticator = None
@@ -62,8 +62,8 @@ class Encryptor(object):
 
 class Decryptor(object):
     def __init__(self, rsa_private_key_pem):
-        if isinstance(rsa_private_key_pem, str):
-            rsa_private_key_pem = rsa_private_key_pem.encode("utf-8")
+        if not isinstance(rsa_private_key_pem, bytes):
+            rsa_private_key_pem = rsa_private_key_pem.encode("ascii")
         self.rsa_private_key = serialization.load_pem_private_key(rsa_private_key_pem, password=None, backend=default_backend())
         self.cipher = None
         self.authenticator = None

--- a/pghoard/encryptor.py
+++ b/pghoard/encryptor.py
@@ -122,7 +122,9 @@ class DecryptorFile(io.BufferedIOBase):
         super(DecryptorFile, self).__init__()
         self.buffer = b""
         self.buffer_offset = 0
-        self.decryptor = Decryptor(rsa_private_key_pem)
+        self.decryptor = None
+        self.key = rsa_private_key_pem
+        self.offset = 0
         self.state = "OPEN"
         self.source_fp = source_fp
 
@@ -131,6 +133,11 @@ class DecryptorFile(io.BufferedIOBase):
             raise ValueError("I/O operation on closed file")
 
     def _read_all(self):
+        if self.state == "EOF":
+            retval = self.buffer[self.buffer_offset:]
+            self.buffer_offset = 0
+            self.buffer = b""
+            return retval
         blocks = []
         if self.buffer_offset > 0:
             blocks.append(self.buffer)
@@ -140,13 +147,15 @@ class DecryptorFile(io.BufferedIOBase):
             data = self.source_fp.read(IO_BLOCK_SIZE)
             if not data:
                 self.state = "EOF"
+                data = self.decryptor.finalize()
+                if data:
+                    blocks.append(data)
+                    self.offset += len(data)
                 break
             data = self.decryptor.update(data)
             if data:
+                self.offset += len(data)
                 blocks.append(data)
-        data = self.decryptor.finalize()
-        if data:
-            blocks.append(data)
         return b"".join(blocks)
 
     def _read_block(self, size):
@@ -154,6 +163,12 @@ class DecryptorFile(io.BufferedIOBase):
         if size <= readylen:
             retval = self.buffer[self.buffer_offset:self.buffer_offset + size]
             self.buffer_offset += size
+            self.offset += len(retval)
+            return retval
+        if self.state == "EOF":
+            retval = self.buffer[self.buffer_offset:]
+            self.buffer_offset = 0
+            self.buffer = b""
             return retval
         blocks = []
         if self.buffer_offset:
@@ -182,6 +197,7 @@ class DecryptorFile(io.BufferedIOBase):
             retval = self.buffer
             self.buffer = b""
             self.buffer_offset = 0
+        self.offset += len(retval)
         return retval
 
     def close(self):
@@ -206,12 +222,17 @@ class DecryptorFile(io.BufferedIOBase):
 
     def peek(self, size=-1):  # pylint: disable=unused-argument
         self._check_not_closed()
-        # XXX
-        return b""
+        if len(self.buffer):
+            return self.buffer
+        data = self.read(size)
+        self.buffer += data
+        return data
 
     def read(self, size=-1):
         """Read up to size decrypted bytes"""
         self._check_not_closed()
+        if not self.decryptor:
+            self.decryptor = Decryptor(self.key)
         if self.state == "EOF" or size == 0:
             return b""
         elif size < 0:
@@ -227,22 +248,53 @@ class DecryptorFile(io.BufferedIOBase):
         self._check_not_closed()
         return self.state in ["OPEN", "EOF"]
 
-    def seek(self, offset, whence=0):  # pylint: disable=unused-argument
+    def seek(self, offset, whence=0):
         self._check_not_closed()
-        raise OSError("Seek on a stream that is not seekable")
+        if whence == 0:
+            if offset < 0:
+                raise ValueError("negative seek position")
+            if self.offset == offset:
+                return self.offset
+            elif self.offset < offset:
+                _ = self.read(offset - self.offset)
+                return self.offset
+            elif self.offset > offset:
+                # simulate backward seek by restarting from the beginning
+                self.buffer = b""
+                self.buffer_offset = 0
+                self.source_fp.seek(0)
+                self.offset = 0
+                self.decryptor = None
+                self.state = "OPEN"
+                _ = self.read(offset)
+                return self.offset
+            else:
+                _ = self.read(self.offset - offset)
+                return self.offset
+        elif whence == 1:
+            if offset != 0:
+                raise io.UnsupportedOperation("can't do nonzero cur-relative seeks")
+            return self.offset
+        elif whence == 2:
+            if offset != 0:
+                raise io.UnsupportedOperation("can't do nonzero end-relative seeks")
+            _ = self.read()
+            return self.offset
+        else:
+            raise ValueError("Invalid whence value")
 
     def seekable(self):
         """True if this stream supports random access"""
         self._check_not_closed()
-        return False
+        return self.source_fp.seekable()
 
     def tell(self):
         self._check_not_closed()
-        raise OSError("Tell on a stream that is not seekable")
+        return self.offset
 
     def truncate(self):
         self._check_not_closed()
-        raise OSError("Truncate on a stream that is not seekable")
+        raise io.UnsupportedOperation("Truncate not supported")
 
     def writable(self):
         """True if this stream supports writing"""

--- a/test/base.py
+++ b/test/base.py
@@ -16,7 +16,7 @@ except ImportError:
     from mock import Mock  # pylint: disable=import-error, no-name-in-module, unused-import
 
 
-CONSTANT_TEST_RSA_PUBLIC_KEY = b"""\
+CONSTANT_TEST_RSA_PUBLIC_KEY = """\
 -----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQ9yu7rNmu0GFMYeQq9Jo2B3d9
 hv5t4a+54TbbxpJlks8T27ipgsaIjqiQP7+uXNfU6UCzGFEHs9R5OELtO3Hq0Dn+
@@ -24,7 +24,7 @@ JGdxJlJ1prxVkvjCICCpiOkhc2ytmn3PWRuVf2VyeAddslEWHuXhZPptvIr593kF
 lWN+9KPe+5bXS8of+wIDAQAB
 -----END PUBLIC KEY-----"""
 
-CONSTANT_TEST_RSA_PRIVATE_KEY = b"""\
+CONSTANT_TEST_RSA_PRIVATE_KEY = """\
 -----BEGIN PRIVATE KEY-----
 MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAND3K7us2a7QYUxh
 5Cr0mjYHd32G/m3hr7nhNtvGkmWSzxPbuKmCxoiOqJA/v65c19TpQLMYUQez1Hk4

--- a/test/test_encryptor.py
+++ b/test/test_encryptor.py
@@ -6,6 +6,7 @@ See LICENSE for details
 """
 from .base import PGHoardTestCase, CONSTANT_TEST_RSA_PUBLIC_KEY, CONSTANT_TEST_RSA_PRIVATE_KEY
 from pghoard.encryptor import Decryptor, DecryptorFile, Encryptor
+import json
 import tarfile
 import tempfile
 
@@ -25,6 +26,11 @@ class TestEncryptor(PGHoardTestCase):
         decryptor = Decryptor(CONSTANT_TEST_RSA_PRIVATE_KEY)
         result = decryptor.update(ciphertext) + decryptor.finalize()
         self.assertEqual(plaintext, result)
+        public_key = json.loads(json.dumps(CONSTANT_TEST_RSA_PUBLIC_KEY))
+        private_key = json.loads(json.dumps(CONSTANT_TEST_RSA_PRIVATE_KEY))
+        encryptor = Encryptor(public_key)
+        decryptor = Decryptor(private_key)
+        self.assertEqual(plaintext, decryptor.update(encryptor.update(plaintext) + encryptor.finalize()) + decryptor.finalize())
 
     def test_decryptorfile(self):
         plaintext = b"test"

--- a/test/test_encryptor.py
+++ b/test/test_encryptor.py
@@ -6,6 +6,7 @@ See LICENSE for details
 """
 from .base import PGHoardTestCase, CONSTANT_TEST_RSA_PUBLIC_KEY, CONSTANT_TEST_RSA_PRIVATE_KEY
 from pghoard.encryptor import Decryptor, DecryptorFile, Encryptor
+import tarfile
 import tempfile
 
 
@@ -29,9 +30,50 @@ class TestEncryptor(PGHoardTestCase):
         plaintext = b"test"
         encryptor = Encryptor(CONSTANT_TEST_RSA_PUBLIC_KEY)
         ciphertext = encryptor.update(plaintext) + encryptor.finalize()
-        fp = tempfile.TemporaryFile()
+        fp = tempfile.TemporaryFile(prefix="test-pghoard.", mode="r+b")
         fp.write(ciphertext)
         fp.seek(0)
         fp = DecryptorFile(fp, CONSTANT_TEST_RSA_PRIVATE_KEY)
         result = fp.read()
         self.assertEqual(plaintext, result)
+        fp.seek(0)
+        result = fp.read()
+        self.assertEqual(plaintext, result)
+        fp.seek(2)
+        result = fp.read(1)
+        self.assertEqual(plaintext[2:3], result)
+
+    def test_decryptorfile_for_tarfile(self):
+        testdata = b"file contents"
+        data_tmp = tempfile.NamedTemporaryFile(prefix="test-pghoard.", mode="r+b")
+        data_tmp.write(testdata)
+        data_tmp.flush()
+
+        tmp = tempfile.TemporaryFile(prefix="test-pghoard.", mode="r+b")
+        tar = tarfile.TarFile(fileobj=tmp, mode="w")
+        tar.add(data_tmp.name, arcname="archived_content")
+        tar.close()
+
+        tmp.seek(0)
+        plaintext = tmp.read()
+
+        tmp.seek(0)
+        tmp.truncate()
+        encryptor = Encryptor(CONSTANT_TEST_RSA_PUBLIC_KEY)
+        ciphertext = encryptor.update(plaintext) + encryptor.finalize()
+        tmp.write(ciphertext)
+
+        tmp.seek(0)
+        tmp = DecryptorFile(tmp, CONSTANT_TEST_RSA_PRIVATE_KEY)
+        tar = tarfile.TarFile(fileobj=tmp, mode="r")
+        info = tar.getmember("archived_content")
+        self.assertTrue(info.isfile())
+        self.assertEqual(info.size, len(testdata))
+        content_file = tar.extractfile("archived_content")
+        tar.extract("archived_content", "/tmp/testout")
+        content = content_file.read()  # pylint: disable=no-member
+        content_file.close()  # pylint: disable=no-member
+        self.assertEqual(testdata, content)
+        tar.close()
+        tmp.close()
+        data_tmp.close()


### PR DESCRIPTION
Contrary to the documentation, TarFile does perform seeks around the underlying fileobj.

Since there's no easy access to cipher state, we can only simulate backward seeks via restart and progress forward.