### PR TITLE
s3: bypass bucket validation errors to support stricter bucket ACLs

### DIFF
--- a/pghoard/object_storage/s3.py
+++ b/pghoard/object_storage/s3.py
@@ -112,6 +112,9 @@ class S3Transfer(BaseTransfer):
         except boto.exception.S3ResponseError as ex:
             if ex.status == 404:
                 bucket = None
+            elif ex.status == 403:
+                self.log.warning("Failed to verify access to bucket, proceeding without validation")
+                bucket = self.conn.get_bucket(bucket_name, validate=False)
             elif ex.status == 301:
                 # Bucket exists on another region, find out which
                 location = self.conn.get_bucket(bucket_name, validate=False).get_location()


### PR DESCRIPTION
Bypass but warn about bucket validation errors for S3. Bucket validation requires AWS IAM ListObjects permissions to the whole bucket without prefix limitations. In some cases, it may make sense to disallow listing of objects on bucket level, and e.g. allow listing for objects in apriori known pghoard site.