### PR TITLE
storage: support path prefixes when storing content

### DIFF
--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -31,7 +31,7 @@ class Compressor(Thread):
             rest, backupname = os.path.split(rest)
         else:
             backupname = os.path.basename(original_path)
-        return os.path.join(self.config["backup_location"], site, filetype, backupname)
+        return os.path.join(self.config["backup_location"], self.config.get("path_prefix", ""), site, filetype, backupname)
 
     def find_site_for_file(self, filepath):
         # Formats like:

--- a/pghoard/object_storage/__init__.py
+++ b/pghoard/object_storage/__init__.py
@@ -94,8 +94,10 @@ class TransferAgent(Thread):
     @staticmethod
     def form_key_path(file_to_transfer):
         name = os.path.basename(file_to_transfer["local_path"])
-        key = "/".join([file_to_transfer["site"], file_to_transfer["filetype"], name])
-        return key
+        return os.path.join(file_to_transfer["path_prefix"],
+                            file_to_transfer["site"],
+                            file_to_transfer["filetype"],
+                            name)
 
     def run(self):
         while self.running:
@@ -108,6 +110,7 @@ class TransferAgent(Thread):
             self.log.debug("Starting to %r %r, size: %r",
                            file_to_transfer["type"], file_to_transfer["local_path"],
                            file_to_transfer.get("file_size", "unknown"))
+            file_to_transfer.setdefault("path_prefix", self.config.get("path_prefix", ""))
             start_time = time.time()
             key = self.form_key_path(file_to_transfer)
             oper = file_to_transfer["type"].lower()

--- a/pghoard/object_storage/azure.py
+++ b/pghoard/object_storage/azure.py
@@ -33,7 +33,7 @@ class AzureTransfer(BaseTransfer):
 
     def list_path(self, path):
         return_list = []
-        path = fix_path(path)
+        path = fix_path(path).rstrip("/") + "/"
         self.log.info("Asking for listing of: %r", path)
         for r in self.conn.list_blobs(self.container_name, prefix=path, delimiter="/",
                                       include="metadata"):

--- a/pghoard/object_storage/google.py
+++ b/pghoard/object_storage/google.py
@@ -56,6 +56,7 @@ class GoogleTransfer(BaseTransfer):
     def list_path(self, path):
         self.log.info("Asking for listing of: %r", path)
         return_list = []
+        path = path.rstrip("/") + "/"
         for item in unpaginate(self.gs_objects, lambda o: o.list(bucket=self.bucket_name, delimiter="/", prefix=path)):
             if item["name"].endswith("/"):
                 continue  # skip directory level objects

--- a/pghoard/object_storage/s3.py
+++ b/pghoard/object_storage/s3.py
@@ -23,8 +23,14 @@ def _location_for_region(region):
 
 
 class S3Transfer(BaseTransfer):
-    def __init__(self, aws_access_key_id, aws_secret_access_key, region, bucket_name,
-                 host=None, port=None, is_secure=False):
+    def __init__(self,
+                 aws_access_key_id,
+                 aws_secret_access_key,
+                 region,
+                 bucket_name,
+                 host=None,
+                 port=None,
+                 is_secure=False):
         BaseTransfer.__init__(self)
         self.region = region
         self.location = _location_for_region(region)
@@ -57,7 +63,7 @@ class S3Transfer(BaseTransfer):
 
     def list_path(self, path):
         return_list = []
-        for r in self.bucket.list(path, "/"):
+        for r in self.bucket.list(path.rstrip("/") + "/", "/"):
             return_list.append({
                 "name": r.name,
                 "size": r.size,

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -60,7 +60,7 @@ class TestWebServer(object):
         # basebackups as it's not possible to request a basebackup to be
         # written to a file and get_archive_file returns a boolean status
         aresult = http_restore.get_archive_file("basebackups/" + backups[0]["name"],
-                                                target_path="dltest", path_prefix=tmpdir)
+                                                target_path="dltest", target_path_prefix=tmpdir)
         assert aresult is True
         # test restoring using get_basebackup_file_to_fileobj
         with open(os.path.join(tmpdir, "b.tar"), "wb") as fp:
@@ -146,7 +146,7 @@ class TestWebServer(object):
         with open(backup_xlog_path + ".metadata", "w") as fp:
             json.dump({"compression-algorithm": "lzma", "original-file-size": len(content)}, fp)
         assert http_restore.query_archive_file(xlog_file) is True
-        http_restore.get_archive_file(xlog_file, "pg_xlog/" + xlog_file, path_prefix=pgdata)
+        http_restore.get_archive_file(xlog_file, "pg_xlog/" + xlog_file, target_path_prefix=pgdata)
         assert os.path.exists(os.path.join(pgdata, "pg_xlog", xlog_file)) is True
         with open(os.path.join(pgdata, "pg_xlog", xlog_file), "rb") as fp:
             restored_data = fp.read()
@@ -171,7 +171,7 @@ class TestWebServer(object):
                 "private": CONSTANT_TEST_RSA_PRIVATE_KEY,
             },
         }
-        http_restore.get_archive_file(xlog_file, "pg_xlog/" + xlog_file, path_prefix=pgdata)
+        http_restore.get_archive_file(xlog_file, "pg_xlog/" + xlog_file, target_path_prefix=pgdata)
         assert os.path.exists(os.path.join(pgdata, "pg_xlog", xlog_file))
         with open(os.path.join(pgdata, "pg_xlog", xlog_file), "rb") as fp:
             restored_data = fp.read()


### PR DESCRIPTION
Add support for optional path prefixes for stored content. This allows some organization of pghoard backups within a shared storage.