### PR TITLE
object_storage: add optional prefix to storage configuration

### DIFF
--- a/pghoard/object_storage/__init__.py
+++ b/pghoard/object_storage/__init__.py
@@ -35,12 +35,14 @@ def get_object_storage_transfer(config, site):
             account_name=storage_config["account_name"],
             account_key=storage_config["account_key"],
             container_name=storage_config.get("container_name", "pghoard"),
+            prefix=storage_config.get("prefix"),
         )
     elif storage_type == "google":
         from pghoard.object_storage.google import GoogleTransfer
         return GoogleTransfer(
             project_id=storage_config["project_id"],
             bucket_name=storage_config.get("bucket_name", "pghoard"),
+            prefix=storage_config.get("prefix"),
             credential_file=storage_config.get("credential_file"),
         )
     elif storage_type == "s3":
@@ -50,6 +52,7 @@ def get_object_storage_transfer(config, site):
             aws_secret_access_key=storage_config["aws_secret_access_key"],
             region=storage_config.get("region", ""),
             bucket_name=storage_config["bucket_name"],
+            prefix=storage_config.get("prefix"),
             host=storage_config.get("host"),
             port=storage_config.get("port"),
             is_secure=storage_config.get("is_secure", False),

--- a/pghoard/object_storage/base.py
+++ b/pghoard/object_storage/base.py
@@ -4,30 +4,55 @@ pghoard
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
+from pghoard.errors import StorageError
 import logging
 
 
 class BaseTransfer(object):
-    def __init__(self):
+    def __init__(self, prefix):
         self.log = logging.getLogger(self.__class__.__name__)
+        if not prefix:
+            prefix = ""
+        elif prefix[-1] != "/":
+            prefix += "/"
+        self.prefix = prefix
+
+    def format_key_for_backend(self, key, trailing_slash=False):
+        """Add a possible prefix to the key before sending it to the backend"""
+        path = self.prefix + key
+        if trailing_slash and path[-1] != "/":
+            path += "/"
+        return path
+
+    def format_key_from_backend(self, key):
+        """Strip the configured prefix from a key retrieved from the backend
+        before passing it on to other pghoard code and presenting it to the
+        user."""
+        if not self.prefix:
+            return key
+        if not key.startswith(self.prefix):
+            raise StorageError("Key {!r} does not start with expected prefix {!r}".format(key, self.prefix))
+        return key[len(self.prefix):]
 
     def delete_key(self, key):
         raise NotImplementedError
 
     def get_contents_to_file(self, key, path):
+        """Write key contents to file pointed by `path` and return metadata"""
         raise NotImplementedError
 
     def get_contents_to_string(self, key):
+        """Returns a tuple (content-byte-string, metadata)"""
         raise NotImplementedError
 
     def get_metadata_for_key(self, key):
         raise NotImplementedError
 
-    def list_path(self, path):
+    def list_path(self, key):
         raise NotImplementedError
 
-    def store_file_from_memory(self, obj_key, memstring, metadata=None):
+    def store_file_from_memory(self, key, memstring, metadata=None):
         raise NotImplementedError
 
-    def store_file_from_disk(self, obj_key, filepath, metadata=None):
+    def store_file_from_disk(self, key, filepath, metadata=None):
         raise NotImplementedError

--- a/pghoard/object_storage/google.py
+++ b/pghoard/object_storage/google.py
@@ -35,8 +35,8 @@ def unpaginate(domain, initial_op):
 
 
 class GoogleTransfer(BaseTransfer):
-    def __init__(self, project_id, bucket_name, credential_file=None):
-        BaseTransfer.__init__(self)
+    def __init__(self, project_id, bucket_name, credential_file=None, prefix=None):
+        BaseTransfer.__init__(self, prefix=prefix)
         self.project_id = project_id
         if credential_file:
             creds = GoogleCredentials.from_stream(credential_file)
@@ -48,40 +48,46 @@ class GoogleTransfer(BaseTransfer):
         self.bucket_name = self.get_or_create_bucket(bucket_name)
         self.log.debug("GoogleTransfer initialized")
 
-    def get_metadata_for_key(self, obj_key):
-        req = self.gs_objects.get(bucket=self.bucket_name, object=obj_key)
+    def get_metadata_for_key(self, key):
+        key = self.format_key_for_backend(key)
+        return self._metadata_for_key(key)
+
+    def _metadata_for_key(self, key):
+        req = self.gs_objects.get(bucket=self.bucket_name, object=key)
         obj = req.execute()
         return obj.get("metadata", {})
 
-    def list_path(self, path):
-        self.log.info("Asking for listing of: %r", path)
+    def list_path(self, key):
+        path = self.format_key_for_backend(key, trailing_slash=True)
+        self.log.debug("Listing path %r", path)
         return_list = []
-        path = path.rstrip("/") + "/"
         for item in unpaginate(self.gs_objects, lambda o: o.list(bucket=self.bucket_name, delimiter="/", prefix=path)):
             if item["name"].endswith("/"):
                 continue  # skip directory level objects
 
             return_list.append({
-                "name": item["name"],
+                "name": self.format_key_from_backend(item["name"]),
                 "size": int(item["size"]),
                 "last_modified": dateutil.parser.parse(item["updated"]),
                 "metadata": item.get("metadata", {}),
                 })
         return return_list
 
-    def delete_key(self, obj_key):
-        self.log.debug("Deleting key: %r", obj_key)
-        request = self.gs_objects.delete(bucket=self.bucket_name, object=obj_key)
+    def delete_key(self, key):
+        key = self.format_key_for_backend(key)
+        self.log.debug("Deleting key: %r", key)
+        request = self.gs_objects.delete(bucket=self.bucket_name, object=key)
         request.execute()
         return True
 
-    def get_contents_to_file(self, obj_key, filepath_to_store_to):
-        self.log.debug("Starting to fetch the contents of: %r to: %r", obj_key, filepath_to_store_to)
+    def get_contents_to_file(self, key, filepath_to_store_to):
+        key = self.format_key_for_backend(key)
+        self.log.debug("Starting to fetch the contents of: %r to: %r", key, filepath_to_store_to)
         fileobj = FileIO(filepath_to_store_to, mode="wb")
         done = False
         metadata = {}
         try:
-            metadata = self.get_contents_to_fileobj(obj_key, fileobj)
+            metadata = self.get_contents_to_fileobj(key, fileobj)
             done = True
         finally:
             fileobj.close()
@@ -89,37 +95,41 @@ class GoogleTransfer(BaseTransfer):
                 os.unlink(filepath_to_store_to)
         return metadata
 
-    def get_contents_to_fileobj(self, obj_key, fileobj_to_store_to):
-        done = False
-        request = self.gs_objects.get_media(bucket=self.bucket_name, object=obj_key)
+    def get_contents_to_fileobj(self, key, fileobj_to_store_to):
+        key = self.format_key_for_backend(key)
+        request = self.gs_objects.get_media(bucket=self.bucket_name, object=key)
         download = MediaIoBaseDownload(fileobj_to_store_to, request, chunksize=CHUNK_SIZE)
+        done = False
         while not done:
             status, done = download.next_chunk()
             if status:
-                self.log.debug("Download of %r: %d%%", obj_key, status.progress() * 100)
-        return self.get_metadata_for_key(obj_key)
+                self.log.debug("Download of %r: %d%%", key, status.progress() * 100)
+        return self._metadata_for_key(key)
 
-    def get_contents_to_string(self, obj_key):
-        self.log.debug("Starting to fetch the contents of: %r", obj_key)
-        request = self.gs_objects.get_media(bucket=self.bucket_name, object=obj_key)
+    def get_contents_to_string(self, key):
+        key = self.format_key_for_backend(key)
+        self.log.debug("Starting to fetch the contents of: %r", key)
+        request = self.gs_objects.get_media(bucket=self.bucket_name, object=key)
         data = request.execute()
-        return data, self.get_metadata_for_key(obj_key)
+        return data, self._metadata_for_key(key)
 
-    def _upload(self, upload_type, local_object, obj_key, metadata):
-        upload = upload_type(local_object, mimetype="application/octet-stream", resumable=True, chunksize=CHUNK_SIZE)
-        request = self.gs_objects.insert(bucket=self.bucket_name, name=obj_key,
+    def _upload(self, upload_type, local_object, key, metadata):
+        key = self.format_key_for_backend(key)
+        upload = upload_type(local_object, mimetype="application/octet-stream",
+                             resumable=True, chunksize=CHUNK_SIZE)
+        request = self.gs_objects.insert(bucket=self.bucket_name, name=key,
                                          media_body=upload, body={"metadata": metadata})
         response = None
         while response is None:
             status, response = request.next_chunk()
             if status:
-                self.log.debug("Upload of %r to %r: %d%%", local_object, obj_key, status.progress() * 100)
+                self.log.debug("Upload of %r to %r: %d%%", local_object, key, status.progress() * 100)
 
-    def store_file_from_memory(self, obj_key, memstring, metadata=None):
-        return self._upload(MediaIoBaseUpload, BytesIO(memstring), obj_key, metadata)
+    def store_file_from_memory(self, key, memstring, metadata=None):
+        return self._upload(MediaIoBaseUpload, BytesIO(memstring), key, metadata)
 
-    def store_file_from_disk(self, obj_key, filepath, metadata=None):
-        return self._upload(MediaFileUpload, filepath, obj_key, metadata)
+    def store_file_from_disk(self, key, filepath, metadata=None):
+        return self._upload(MediaFileUpload, filepath, key, metadata)
 
     def get_or_create_bucket(self, bucket_name):
         """Try to create the bucket and quietly handle the case where it


### PR DESCRIPTION
Add a new optional object storage configuration key `prefix` to allow
prefixing all operations in the store with a custom prefix.  This
supplements the per key prefixes that we already have and makes it easier to
further subdivide a common S3 or Google bucket.