### PR TITLE
webserver: prefetch files on restore

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,10 +1,10 @@
 [MESSAGES CONTROL]
-disable=I,
+disable=
     bad-option-value,
     duplicate-code,
     fixme,
     invalid-name,
-    line-too-long,
+    locally-disabled,
     missing-docstring,
     no-self-use,
     too-few-public-methods,
@@ -18,6 +18,9 @@ disable=I,
     ungrouped-imports,
     wrong-import-order,
     wrong-import-position
+
+[FORMAT]
+max-line-length=125
 
 [REPORTS]
 output-format=text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - "3.5"
 
 install:
-  - "pip install boto cryptography mock pep8 psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests"
+  - "pip install boto cryptography flake8 mock psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests"
 
 script:
   - "make pylint"
-  - "make pep8"
+  - "make flake8"
   - "make unittest"
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ rpm:
 build-dep-fed:
 	sudo yum -y install postgresql-server \
 		python3-boto python3-cryptography python3-dateutil \
-		python3-pep8 python3-psycopg2 python3-pylint python3-pytest \
+		python3-flake8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests python3-snappy \
 		rpm-build
 
-test: pep8 pylint unittest
+test: flake8 pylint unittest
 
 unittest:
 	$(PYTHON) -m pytest $(PYTEST_ARG) test/
@@ -42,8 +42,5 @@ coverage:
 pylint:
 	$(PYTHON) -m pylint.lint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
 
-pep8:
-	$(PYTHON) -m pep8 --ignore=E501,E123 $(PYTHON_SOURCE_DIRS)
-
-autopep8:
-	$(PYTHON) -m autopep8 --recursive --jobs=0 --in-place --max-line-length=100 --ignore E24,E265 $(PYTHON_SOURCE_DIRS)
+flake8:
+	$(PYTHON) -m flake8 --max-line-len=125 $(PYTHON_SOURCE_DIRS)

--- a/README.rst
+++ b/README.rst
@@ -343,6 +343,13 @@ means the absolute path to the PostgreSQL pg_xlog directory.  Note that
 pghoard will need to be able to read files from the directory in order to
 back them up.
 
+``restore_prefetch`` (default ``min(compression.thread_count,
+transfer.thread_count) - 1``)
+
+Number of files to prefetch when performing archive recovery.  The default
+is the lower of Compression or Transfer Agent threads minus one to perform
+all operations in parallel when a single backup site is used.
+
 ``syslog`` (default ``false``)
 
 Determines whether syslog logging should be turned on or not.

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -9,7 +9,7 @@ Requires(pre):  shadow-utils
 Requires:       postgresql-server, systemd
 Requires:       python3-boto, python3-cryptography python3-dateutil
 Requires:       python3-psycopg2, python3-requests, python3-snappy
-BuildRequires:  python3-pep8, python3-pytest, python3-pylint, python3-devel
+BuildRequires:  python3-flake8, python3-pytest, python3-pylint, python3-devel
 BuildArch:      noarch
 
 %description

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -211,7 +211,8 @@ class Compressor(Thread):
         start_time = time.time()
         data = event["blob"]
         if "metadata" in event and "encryption-key-id" in event["metadata"]:
-            rsa_private_key = self.config["backup_sites"][event["site"]]["encryption_keys"][event["metadata"]["encryption-key-id"]]["private"]
+            key_id = event["metadata"]["encryption-key-id"]
+            rsa_private_key = self.config["backup_sites"][event["site"]]["encryption_keys"][key_id]["private"]
             decryptor = Decryptor(rsa_private_key)
             data = decryptor.update(data) + decryptor.finalize()
 

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -175,7 +175,7 @@ class Compressor(Thread):
                     if not filetype:
                         if 'callback_queue' in event and event['callback_queue']:
                             self.log.debug("Returning success for event: %r, even though we did nothing for it", event)
-                            event['callback_queue'].put({"success": True})
+                            event['callback_queue'].put({"success": True, "opaque": event.get("opaque")})
                         continue
                     else:
                         self.handle_event(event, filetype)
@@ -228,7 +228,7 @@ class Compressor(Thread):
                        time.time() - start_time)
 
         if 'callback_queue' in event:
-            event['callback_queue'].put({"success": True})
+            event['callback_queue'].put({"success": True, "opaque": event.get("opaque")})
 
     def handle_event(self, event, filetype):
         start_time, compressed_blob = time.time(), None
@@ -274,6 +274,7 @@ class Compressor(Thread):
             "file_size": compressed_file_size,
             "filetype": filetype,
             "metadata": metadata,
+            "opaque": event.get("opaque"),
             "site": site,
             "type": "UPLOAD",
         }

--- a/pghoard/create_keys.py
+++ b/pghoard/create_keys.py
@@ -18,11 +18,16 @@ def create_keys(bits):
     rsa_private_key = rsa.generate_private_key(public_exponent=65537,
                                                key_size=bits,
                                                backend=default_backend())
-    rsa_private_key_pem = rsa_private_key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.PKCS8, encryption_algorithm=serialization.NoEncryption())
+    rsa_private_key_pem = rsa_private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption())
 
     rsa_public_key = rsa_private_key.public_key()
 
-    rsa_public_key_pem = rsa_public_key.public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+    rsa_public_key_pem = rsa_public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
     return rsa_private_key_pem, rsa_public_key_pem
 

--- a/pghoard/encryptor.py
+++ b/pghoard/encryptor.py
@@ -65,7 +65,10 @@ class Decryptor(object):
     def __init__(self, rsa_private_key_pem):
         if not isinstance(rsa_private_key_pem, bytes):
             rsa_private_key_pem = rsa_private_key_pem.encode("ascii")
-        self.rsa_private_key = serialization.load_pem_private_key(rsa_private_key_pem, password=None, backend=default_backend())
+        self.rsa_private_key = serialization.load_pem_private_key(
+            data=rsa_private_key_pem,
+            password=None,
+            backend=default_backend())
         self.cipher = None
         self.authenticator = None
         self.buf = b""
@@ -257,7 +260,7 @@ class DecryptorFile(io.BufferedIOBase):
             if self.offset == offset:
                 return self.offset
             elif self.offset < offset:
-                _ = self.read(offset - self.offset)
+                self.read(offset - self.offset)
                 return self.offset
             elif self.offset > offset:
                 # simulate backward seek by restarting from the beginning
@@ -267,10 +270,10 @@ class DecryptorFile(io.BufferedIOBase):
                 self.offset = 0
                 self.decryptor = None
                 self.state = "OPEN"
-                _ = self.read(offset)
+                self.read(offset)
                 return self.offset
             else:
-                _ = self.read(self.offset - offset)
+                self.read(self.offset - offset)
                 return self.offset
         elif whence == 1:
             if offset != 0:
@@ -279,7 +282,7 @@ class DecryptorFile(io.BufferedIOBase):
         elif whence == 2:
             if offset != 0:
                 raise io.UnsupportedOperation("can't do nonzero end-relative seeks")
-            _ = self.read()
+            self.read()
             return self.offset
         else:
             raise ValueError("Invalid whence value")

--- a/pghoard/object_storage/__init__.py
+++ b/pghoard/object_storage/__init__.py
@@ -152,26 +152,26 @@ class TransferAgent(Thread):
             storage = self.get_object_storage(site)
             items = storage.list_path(key)
             file_to_transfer["file_size"] = len(repr(items))  # approx
-            return {"success": True, "items": items}
+            return {"success": True, "items": items, "opaque": file_to_transfer.get("opaque")}
         except Exception as ex:  # pylint: disable=broad-except
             if isinstance(ex, FileNotFoundFromStorageError):
                 self.log.warning("%r not found from storage", key)
             else:
                 self.log.exception("Problem happened when retrieving metadata: %r, %r", key, file_to_transfer)
-            return {"success": False, "exception": ex}
+            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
 
     def handle_metadata(self, site, key, file_to_transfer):
         try:
             storage = self.get_object_storage(site)
             metadata = storage.get_metadata_for_key(key)
             file_to_transfer["file_size"] = len(repr(metadata))  # approx
-            return {"success": True, "metadata": metadata}
+            return {"success": True, "metadata": metadata, "opaque": file_to_transfer.get("opaque")}
         except Exception as ex:  # pylint: disable=broad-except
             if isinstance(ex, FileNotFoundFromStorageError):
                 self.log.warning("%r not found from storage", key)
             else:
                 self.log.exception("Problem happened when retrieving metadata: %r, %r", key, file_to_transfer)
-            return {"success": False, "exception": ex}
+            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
 
     def handle_download(self, site, key, file_to_transfer):
         try:
@@ -185,6 +185,7 @@ class TransferAgent(Thread):
                 "callback_queue": file_to_transfer["callback_queue"],
                 "local_path": file_to_transfer["target_path"],
                 "metadata": metadata,
+                "opaque": file_to_transfer.get("opaque"),
                 "site": site,
                 "type": "DECOMPRESSION",
             })
@@ -194,7 +195,7 @@ class TransferAgent(Thread):
                 self.log.warning("%r not found from storage", key)
             else:
                 self.log.exception("Problem happened when downloading: %r, %r", key, file_to_transfer)
-            return {"success": False, "exception": ex}
+            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
 
     def handle_upload(self, site, key, file_to_transfer):
         try:
@@ -219,7 +220,7 @@ class TransferAgent(Thread):
                         os.unlink(metadata_path)
                 except:  # pylint: disable=bare-except
                     self.log.exception("Problem in deleting file: %r", file_to_transfer["local_path"])
-            return {"success": True}
+            return {"success": True, "opaque": file_to_transfer.get("opaque")}
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception("Problem in moving file: %r, need to retry", file_to_transfer["local_path"])
             # TODO come up with something so we don't busy loop

--- a/pghoard/object_storage/__init__.py
+++ b/pghoard/object_storage/__init__.py
@@ -14,7 +14,6 @@ from queue import Empty
 from threading import Thread
 import logging
 import os
-import shutil
 import time
 
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -335,10 +335,14 @@ class PGHoard(object):
         """Periodically write a JSON state file to disk"""
         start_time = time.time()
         state_file_path = self.config.get("json_state_file_path", "/tmp/pghoard_state.json")
-        self.state["pg_receivexlogs"] = dict((key, {"latest_activity": value.latest_activity.isoformat(), "running": value.running})
-                                             for key, value in self.receivexlogs.items())
-        self.state["pg_basebackups"] = dict((key, {"latest_activity": value.latest_activity.isoformat(), "running": value.running})
-                                            for key, value in self.basebackups.items())
+        self.state["pg_receivexlogs"] = {
+            key: {"latest_activity": value.latest_activity.isoformat(), "running": value.running}
+            for key, value in self.receivexlogs.items()
+        }
+        self.state["pg_basebackups"] = {
+            key: {"latest_activity": value.latest_activity.isoformat(), "running": value.running}
+            for key, value in self.basebackups.items()
+        }
         self.state["compressors"] = [compressor.state for compressor in self.compressors]
         self.state["transfer_agents"] = [ta.state for ta in self.transfer_agents]
         self.state["queues"] = {

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -67,11 +67,11 @@ class PGHoard(object):
         self.inotify = InotifyWatcher(self.compression_queue)
         self.webserver = WebServer(self.config, self.compression_queue, self.transfer_queue)
 
-        for _ in range(self.config.get("compression", {}).get("thread_count", 5)):
+        for _ in range(self.config["compression"]["thread_count"]):
             compressor = Compressor(self.config, self.compression_queue, self.transfer_queue)
             self.compressors.append(compressor)
 
-        for _ in range(self.config.get("transfer", {}).get("thread_count", 5)):
+        for _ in range(self.config["transfer"]["thread_count"]):
             ta = TransferAgent(self.config, self.compression_queue, self.transfer_queue)
             self.transfer_agents.append(ta)
 
@@ -382,6 +382,15 @@ class PGHoard(object):
             if _signal is not None:
                 return
             raise InvalidConfigurationError(self.config_path)
+
+        # default to 5 compression and transfer threads
+        self.config.setdefault("compression", {}).setdefault("thread_count", 5)
+        self.config.setdefault("transfer", {}).setdefault("thread_count", 5)
+        # default to prefetching min(#compressors, #transferagents) - 1 objects so all
+        # operations where prefetching is used run fully in parallel without waiting to start
+        self.config.setdefault("restore_prefetch", min(
+            self.config["compression"]["thread_count"],
+            self.config["transfer"]["thread_count"]) - 1)
 
         if self.config.get("syslog") and not self.syslog_handler:
             self.syslog_handler = set_syslog_handler(self.config.get("syslog_address", "/dev/log"),

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -95,7 +95,8 @@ class Restore(object):
             cmd.add_argument("--overwrite", help="overwrite existing target directory",
                              default=False, action="store_true")
             cmd.add_argument("--recovery-end-command", help="PostgreSQL recovery_end_command", metavar="COMMAND")
-            cmd.add_argument("--recovery-target-action", help="PostgreSQL recovery_target_action", choices=["pause", "promote", "shutdown"])
+            cmd.add_argument("--recovery-target-action", help="PostgreSQL recovery_target_action",
+                             choices=["pause", "promote", "shutdown"])
             cmd.add_argument("--recovery-target-name", help="PostgreSQL recovery_target_name", metavar="RESTOREPOINT")
             cmd.add_argument("--recovery-target-time", help="PostgreSQL recovery_target_time", metavar="ISO_TIMESTAMP")
             cmd.add_argument("--recovery-target-xid", help="PostgreSQL recovery_target_xid", metavar="XID")
@@ -208,7 +209,9 @@ class Restore(object):
         tmp.seek(0)
         if "encryption-key-id" in metadata:
             # Wrap stream into DecryptorFile object
-            tmp = DecryptorFile(tmp, self.config["backup_sites"][site]["encryption_keys"][metadata["encryption-key-id"]]["private"])  # pylint: disable=redefined-variable-type
+            key_id = metadata["encryption-key-id"]
+            site_keys = self.config["backup_sites"][site]["encryption_keys"]
+            tmp = DecryptorFile(tmp, site_keys[key_id]["private"])  # pylint: disable=redefined-variable-type
 
         if metadata.get("compression-algorithm") == "lzma":
             # Wrap stream into LZMAFile object

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -61,6 +61,7 @@ class TestTransferAgent(PGHoardTestCase):
             "callback_queue": callback_queue,
             "filetype": "xlog",
             "local_path": self.temp_dir,
+            "opaque": 42,
             "site": self.test_site,
             "target_path": self.temp_dir,
             "type": "DOWNLOAD",
@@ -70,6 +71,7 @@ class TestTransferAgent(PGHoardTestCase):
             "callback_queue": callback_queue,
             "local_path": self.temp_dir,
             "metadata": {"key": "value"},
+            "opaque": 42,
             "site": self.test_site,
             "type": "DECOMPRESSION",
         }
@@ -89,7 +91,7 @@ class TestTransferAgent(PGHoardTestCase):
             "site": self.test_site,
             "type": "UPLOAD",
         })
-        assert callback_queue.get(timeout=1.0) == {"success": True}
+        assert callback_queue.get(timeout=1.0) == {"success": True, "opaque": None}
         assert os.path.exists(self.foo_path) is False
 
     def test_handle_upload_basebackup(self):
@@ -106,5 +108,5 @@ class TestTransferAgent(PGHoardTestCase):
             "site": self.test_site,
             "type": "UPLOAD",
         })
-        assert callback_queue.get(timeout=1.0) == {"success": True}
+        assert callback_queue.get(timeout=1.0) == {"success": True, "opaque": None}
         assert os.path.exists(self.foo_basebackup_path) is False


### PR DESCRIPTION
Prefetch files when performing archive recovery using pghoard's restore command against the local pghoard webserver.  The default is to start up to 'lower of Compression or Transfer Agent threads minus one' prefetch operations so we can perform all operations (original request + prefetch) fully in parallel without having to wait for threads to start.

We maintain a negative cache for "file not found" prefetch failures to avoid trying to prefetch the same files multiple times, but the cache isn't used for explicit download requests as the segments may show up in the archive after the first failures.

This speeds up archive recovery a bit in default configurations, but it may make sense to increase thread counts beyond the current defaults (5) if the store is slow or has high latency.