### PR TITLE
wal header check: allow different timelines in wal headers

### DIFF
--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -32,3 +32,11 @@ def read_header(blob):
     lsn = "{:X}/{:X}".format(log, pos)
     filename = "{:08X}{:08X}{:08X}".format(tli, log, seg)
     return WalHeader(version=version, timeline=tli, lsn=lsn, filename=filename)
+
+
+def lsn_from_name(name):
+    n = int(name, 16)
+    log = (n >> 32) & 0xFFFFFFFF
+    seg = n & 0xFFFFFFFF
+    pos = seg * XLOG_SEG_SIZE
+    return "{:X}/{:X}".format(log, pos)

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -173,9 +173,10 @@ class RequestHandler(BaseHTTPRequestHandler):
         except (KeyError, OSError, ValueError) as ex:
             fmt = "WAL file {path!r} verification failed: {ex.__class__.__name__}: {ex}"
             raise HttpResponse(fmt.format(path=path, ex=ex), status=412)
-        if hdr.filename != filename:
-            fmt = "Expected WAL segment {seg!r} in restored WAL file {path!r}; found {found!r}"
-            raise HttpResponse(fmt.format(seg=filename, path=path, found=hdr.filename), status=412)
+        expected_lsn = wal.lsn_from_name(filename)
+        if hdr.lsn != expected_lsn:
+            fmt = "Expected LSN {lsn!r} in restored WAL file {path!r}; found {found!r}"
+            raise HttpResponse(fmt.format(lsn=expected_lsn, path=path, found=hdr.lsn), status=412)
 
     def _save_and_verify_restored_file(self, filetype, filename, tmp_target_path, target_path):
         self._verify_wal(filetype, filename, tmp_target_path)

--- a/test/test_wal.py
+++ b/test/test_wal.py
@@ -7,7 +7,7 @@ See LICENSE for details
 import codecs
 import pytest
 import struct
-from pghoard.wal import read_header, WalHeader, WAL_MAGIC, XLOG_SEG_SIZE
+from pghoard.wal import read_header, lsn_from_name, WalHeader, WAL_MAGIC, XLOG_SEG_SIZE
 
 WAL_HEADER_95 = codecs.decode(b"87d006002f0000000000009c1100000000000000", "hex")
 
@@ -35,3 +35,8 @@ def test_wal_header():
     blob9X = b"\x7F\xd0" + blob95[2:]
     with pytest.raises(KeyError):
         read_header(blob9X)
+
+
+def test_lsn_from_name():
+    assert "11/4000000" == lsn_from_name("0000002E0000001100000004")
+    assert "11/4000000" == lsn_from_name("000000FF0000001100000004")

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -342,9 +342,11 @@ class TestWebServer(object):
         postgres_command.http_request = orig_http_request
 
     def test_get_archived_file(self, pghoard):
-        xlog_seg = "00000001000000000000000F"
+        xlog_seg_prev_tli = "00000001000000000000000F"
+        xlog_seg = "00000002000000000000000F"
         xlog_file = "xlog/{}".format(xlog_seg)
-        content = wal_header_for_file(xlog_seg)
+        # NOTE: create WAL header for the "previous" timeline, this should be accepted
+        content = wal_header_for_file(xlog_seg_prev_tli)
         pgdata = os.path.dirname(pghoard.config["backup_sites"][pghoard.test_site]["pg_xlog_directory"])
         archive_path = os.path.join(pghoard.test_site, xlog_file)
         compressor = pghoard.Compressor()


### PR DESCRIPTION
PostgreSQL doesn't switch to a new xlog immediately after timeline change so
a wal file can contain records for multiple timelines.  Only consider the
log segment numbers when checking headers against filenames.