### PR TITLE
basebackups: make sure more basebackups are taken while running

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -302,7 +302,7 @@ class PGHoard(object):
         for ta in self.transfer_agents:
             ta.start()
 
-    def handle_site(self, site, site_config):
+    def handle_site(self, site, site_config, block=False):
         self.set_state_defaults(site)
         xlog_path, basebackup_path = self.create_backup_site_paths(site)
 
@@ -322,12 +322,25 @@ class PGHoard(object):
             connection_string, slot = replication_connection_string_using_pgpass(chosen_backup_node)
             self.receivexlog_listener(site, xlog_path + "_incoming", connection_string, slot)
 
-        if self.time_since_last_backup.get(site, 0) > self.config['backup_sites'][site]['basebackup_interval_hours'] * 3600 \
-           and site not in self.basebackups:
+        # check if a basebackup is running, or if a basebackup has just completed
+        if site in self.basebackups:
+            if not self.basebackups[site].running:
+                if self.basebackups[site].is_alive():
+                    self.basebackups[site].join()
+                del self.basebackups[site]
+                # reset time_since_last_backup_check so we'll recheck on next iteration
+                self.time_since_last_backup_check[site] = 0
+                self.log.debug("Previous basebackup has finished for %r, resetting it's check timer", site)
+            return
+
+        if self.time_since_last_backup.get(site, 0) > site_config["basebackup_interval_hours"] * 3600:
             self.log.debug("Starting to create a new basebackup for: %r since time from previous: %r",
                            site, self.time_since_last_backup.get(site, 0))
             connection_string, slot = replication_connection_string_using_pgpass(chosen_backup_node)
-            self.create_basebackup(site, connection_string, basebackup_path)
+            callback = Queue() if block else None
+            self.create_basebackup(site, connection_string, basebackup_path, callback)
+            if block:
+                callback.get()
 
     def run(self):
         self.start_threads_on_startup()
@@ -356,7 +369,7 @@ class PGHoard(object):
             "compression_queue": self.compression_queue.qsize(),
             "transfer_queue": self.transfer_queue.qsize(),
             }
-        json_to_dump = json.dumps(self.state, indent=4)
+        json_to_dump = json.dumps(self.state, indent=4, sort_keys=True)
         self.log.debug("Writing JSON state file to: %r, file_size: %r", state_file_path, len(json_to_dump))
         with open(state_file_path + ".tmp", "w") as fp:
             fp.write(json_to_dump)

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -248,7 +248,7 @@ class PGHoard(object):
             entry["name"] = os.path.basename(entry["name"])
             entry["last_modified"] = entry["last_modified"].timestamp()
 
-        results.sort(key=lambda entry: entry["name"])
+        results.sort(key=lambda entry: entry["metadata"]["start-time"])
         return results
 
     def check_backup_count_and_state(self, site):
@@ -260,10 +260,9 @@ class PGHoard(object):
         m_time = basebackups[-1]["last_modified"] if basebackups else 0
 
         while len(basebackups) > allowed_basebackup_count:
-            self.log.warning("Too many basebackups: %d>%d, %r, starting to get rid of %r",
+            self.log.warning("Too many basebackups: %d > %d, %r, starting to get rid of %r",
                              len(basebackups), allowed_basebackup_count, basebackups, basebackups[0]["name"])
-            basebackup_to_be_deleted = basebackups[0]
-            basebackups = basebackups[1:]
+            basebackup_to_be_deleted = basebackups.pop(0)
 
             last_wal_segment_still_needed = 0
             if basebackups:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,6 +118,8 @@ def pghoard(db, tmpdir, request):  # pylint: disable=redefined-outer-name
         "backup_location": os.path.join(str(tmpdir), "backups"),
         "backup_sites": {
             test_site: {
+                "basebackup_count": 2,
+                "basebackup_interval_hours": 24,
                 "pg_xlog_directory": os.path.join(db.pgdata, "pg_xlog"),
                 "nodes": [db.user],
                 "object_storage": {},

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -4,6 +4,7 @@ pghoard
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
+from copy import deepcopy
 from pghoard.basebackup import PGBaseBackup
 from pghoard.common import create_connection_string
 from pghoard.restore import Restore, RestoreError
@@ -11,6 +12,7 @@ from queue import Queue
 import os
 import pytest
 import tarfile
+import time
 
 
 class TestPGBaseBackup(object):
@@ -70,3 +72,37 @@ LABEL: pg_basebackup base backup
             "--overwrite",
         ])
         # TODO: check that the backup is valid
+
+    def test_handle_site(self, pghoard):
+        site_config = deepcopy(pghoard.config["backup_sites"][pghoard.test_site])
+        site_config["basebackup_interval_hours"] = 1 / 36000
+        assert pghoard.basebackups == {}
+
+        pghoard.handle_site(pghoard.test_site, site_config, block=True)
+        assert pghoard.test_site in pghoard.basebackups
+        assert pghoard.basebackups[pghoard.test_site].running is False
+        first_last_activity = pghoard.basebackups[pghoard.test_site].latest_activity
+
+        time.sleep(1)
+
+        # first handle_site() call after a basebackup was taken should clear the timers, but not start a new one
+        pghoard.handle_site(pghoard.test_site, site_config, block=True)
+        assert pghoard.test_site not in pghoard.basebackups
+        # second handle_site() call starts a new basebackup
+        pghoard.handle_site(pghoard.test_site, site_config, block=True)
+        assert pghoard.test_site in pghoard.basebackups
+        assert pghoard.basebackups[pghoard.test_site].running is False
+        second_last_activity = pghoard.basebackups[pghoard.test_site].latest_activity
+
+        assert first_last_activity < second_last_activity
+
+        # reset the timer to something more sensible and make sure we don't trigger any new basebackups
+        site_config["basebackup_interval_hours"] = 1
+
+        time.sleep(1)
+        pghoard.handle_site(pghoard.test_site, site_config, block=True)
+        assert pghoard.test_site not in pghoard.basebackups
+
+        time.sleep(1)
+        pghoard.handle_site(pghoard.test_site, site_config, block=True)
+        assert pghoard.test_site not in pghoard.basebackups

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -69,21 +69,32 @@ class TestPGHoard(PGHoardTestCase):
         metadata_file_path = bb_path + ".metadata"
         with open(bb_path, "wb") as fp:
             fp.write(b"something")
-        with open(metadata_file_path, "wb") as fp:
-            fp.write(b"{\"a\":1}")
+        with open(metadata_file_path, "w") as fp:
+            json.dump({"start-time": "2015-07-03 12:00:00"}, fp)
         available_backup = self.pghoard.get_remote_basebackups_info(self.test_site)[0]
         assert available_backup["name"] == "2015-07-03_0"
-        assert available_backup["metadata"] == {"a": 1}
+        assert available_backup["metadata"] == {"start-time": "2015-07-03 12:00:00"}
 
-        bb_path = os.path.join(self.basebackup_path, "2015-07-02_0")
+        bb_path = os.path.join(self.basebackup_path, "2015-07-02_9")
         metadata_file_path = bb_path + ".metadata"
         with open(bb_path, "wb") as fp:
             fp.write(b"something")
-        with open(metadata_file_path, "wb") as fp:
-            fp.write(b"{}")
+        with open(metadata_file_path, "w") as fp:
+            json.dump({"start-time": "2015-07-02 12:00:00"}, fp)
         basebackups = self.pghoard.get_remote_basebackups_info(self.test_site)
-        assert basebackups[0]["name"] == "2015-07-02_0"
+        assert basebackups[0]["name"] == "2015-07-02_9"
         assert basebackups[1]["name"] == "2015-07-03_0"
+
+        bb_path = os.path.join(self.basebackup_path, "2015-07-02_10")
+        metadata_file_path = bb_path + ".metadata"
+        with open(bb_path, "wb") as fp:
+            fp.write(b"something")
+        with open(metadata_file_path, "w") as fp:
+            json.dump({"start-time": "2015-07-02 22:00:00"}, fp)
+        basebackups = self.pghoard.get_remote_basebackups_info(self.test_site)
+        assert basebackups[0]["name"] == "2015-07-02_9"
+        assert basebackups[1]["name"] == "2015-07-02_10"
+        assert basebackups[2]["name"] == "2015-07-03_0"
 
     def test_local_check_backup_count_and_state(self):
         self.pghoard.set_state_defaults(self.test_site)
@@ -96,7 +107,10 @@ class TestPGHoard(PGHoardTestCase):
                     with open(bb_path, "wb") as fp:
                         fp.write(b"something")
                     with open(bb_path + ".metadata", "w") as fp:
-                        json.dump({"start-wal-segment": wals[0]}, fp)
+                        json.dump({
+                            "start-wal-segment": wals[0],
+                            "start-time": bb,
+                        }, fp)
                 for wal in wals:
                     with open(os.path.join(self.compressed_xlog_path, wal), "wb") as fp:
                         fp.write(b"something")


### PR DESCRIPTION
Clean up previous basebackup threads once they finish to make sure we take
new basebackups when needed, but make sure we reset time of last check when
a new backup is taken to avoid taking too many backups too quickly.  Also
updated tests to handle more cases.