### PR TITLE
basebackups: make sure basebackups are taken and cleaned in a timely manner

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,6 +118,8 @@ def pghoard(db, tmpdir, request):  # pylint: disable=redefined-outer-name
         "backup_location": os.path.join(str(tmpdir), "backups"),
         "backup_sites": {
             test_site: {
+                "basebackup_count": 2,
+                "basebackup_interval_hours": 24,
                 "pg_xlog_directory": os.path.join(db.pgdata, "pg_xlog"),
                 "nodes": [db.user],
                 "object_storage": {},


### PR DESCRIPTION
Clean up previous basebackup threads once they finish to make sure we take
new basebackups when needed, but make sure we reset time of last check when
a new backup is taken to avoid taking too many backups too quickly.

Cleaning up basebackups is now done based on backup start time instead of
backup name, which is not guaranteed to increment alphabetically.

Also updated tests to handle more cases.