### PR TITLE
Cast keys to str before json.dumps

### DIFF
--- a/pghoard/create_keys.py
+++ b/pghoard/create_keys.py
@@ -49,8 +49,8 @@ def main():
                 "encryption_key_id": args.key_id,
                 "encryption_keys": {
                     args.key_id: {
-                        "private": rsa_private_key,
-                        "public": rsa_public_key
+                        "private": str(rsa_private_key),
+                        "public": str(rsa_public_key)
                     }
                 }
             }


### PR DESCRIPTION
I have not confirmed that this output works but I was getting an exception like this before I made this change:

[root@e76f50af6040 ~]# pghoard_create_keys --site hbprod-brian --key-id hbprod-brian
Traceback (most recent call last):
  File "/usr/bin/pghoard_create_keys", line 9, in <module>
    load_entry_point('pghoard==0.9.0', 'console_scripts', 'pghoard_create_keys')()
  File "/usr/lib/python3.4/site-packages/pghoard/create_keys.py", line 60, in main
    print(json.dumps(config, indent=4))
  File "/usr/lib64/python3.4/json/__init__.py", line 237, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.4/json/encoder.py", line 194, in encode
    chunks = list(chunks)
  File "/usr/lib64/python3.4/json/encoder.py", line 422, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib64/python3.4/json/encoder.py", line 396, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.4/json/encoder.py", line 396, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.4/json/encoder.py", line 396, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.4/json/encoder.py", line 396, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.4/json/encoder.py", line 396, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.4/json/encoder.py", line 429, in _iterencode
    o = _default(o)
  File "/usr/lib64/python3.4/json/encoder.py", line 173, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'-----BEGIN PRIVATE KEY-----\nMIIHAAIBADANBgkqhkiG9w0BAQEFAASCBuowggbmAgEAAoIBgQCdHrAbkWA49c2k\nVHYEU2pB7GoeLO8FqoiH1Od4ijskH9G94bAGlhbBTwsx70Pm/EXP4C//OF4fn7Jc\nE+s3ah5yKhXRWu5flnLzexVh9KJToRSKjthVs/T6TNd5D+QSgs3Mfrylp0tyhi/b\nKmYeJKPDuE6SXbDnwkZQVosSv8474uL+xoenugCpxn1q/PDQQ75sKbniSO+KNiCx\n2qArLzEz6Egc9VBclHXmkhFiPv2WnjKFjDKO0e0O7FiGSG/woS4oL7IX0m9yOMuo\nWuQw9Xvmtt8Q5gcvOuG66DKD2YH0WxxhLfj8wzAre++ujUUeBHyUPMR1rEZHTmdz\n3gWiqdTKiB+9jsFKz6gAFR1wVZkQz7Rg5ECw9B9tE