### PR TITLE
README, rpm: update rpm building instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,14 @@ deb:
 rpm:
 	git archive --output=pghoard-rpm-src.tar.gz --prefix=pghoard/ HEAD
 	rpmbuild -bb pghoard.spec \
-		--define '_sourcedir $(shell pwd)' \
+		--define '_topdir $(PWD)/rpm' \
+		--define '_sourcedir $(CURDIR)' \
 		--define 'major_version $(short_ver)' \
 		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))'
 	$(RM) pghoard-rpm-src.tar.gz
 
 build-dep-fed:
-	sudo yum -y install postgresql-server \
+	sudo dnf -y install postgresql-server \
 		python3-boto python3-cryptography python3-dateutil \
 		python3-flake8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests python3-snappy \
@@ -44,3 +45,5 @@ pylint:
 
 flake8:
 	$(PYTHON) -m flake8 --max-line-len=125 $(PYTHON_SOURCE_DIRS)
+
+.PHONY: rpm

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Fedora::
 
   make rpm
 
-This will produce a .rpm package usually into ~/rpmbuild/RPMS/noarch/ .
+This will produce a .rpm package usually into rpm/RPMS/noarch/.
 
 Python/Other::
 
@@ -78,7 +78,7 @@ Debian::
 
 Fedora::
 
-  rpm -Uvh ~/rpmbuild/RPMS/noarch/pghoard*
+  dnf install rpm/RPMS/noarch/*
 
 On Fedora it is recommended to simply run pghoard under systemd::
 
@@ -90,7 +90,7 @@ and eventually after the setup section, you can just run::
 
 Python/Other::
 
-  easy_install dist/pghoard-0.9.0-py2.7.egg
+  easy_install dist/pghoard-0.9.0-py3.4.egg
 
 On Debian/Other systems it is recommended that you run pghoard within a
 supervisord (http://supervisord.org) Process control system.  (see examples


### PR DESCRIPTION
Also changed Pyhon version in the example egg name from 2.7 to 3.4 as we
don't even support Python 2 anymore.