### PR TITLE
basebackup: support encrypting and compressing basebackups on the fly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,18 @@ Determines log level of pghoard.
 
 If a file exists in this location, no new backup actions will be started.
 
+``stream_compression`` (default ``False``)
+
+If you set this to true pghoard will use an optimized way of taking
+a basebackup directly in a compressed and encrypted form saving
+diskspace. The downside is that you can't create have any tablespaces
+other than the default ones and you cannot take other basebackups at
+the same time as pghoard is taking its own. As guidance few
+installations use extra tablespaces and if you already use pghoard to
+take basebackups, you will not need to take other basebackups yourself
+meaning this option is probably safe to use but you need to opt in
+explicitly in order to benefit from it.
+
 ``object_storage`` (no default)
 
 Configured in ``backup_sites`` under a specific site.  If set, it must be an
@@ -294,7 +306,7 @@ object describing a remote object storage.  The object must contain a key
 ``storage_type`` describing the type of the store, other keys and values are
 specific to the storage type.
 
-The following object storage types are suppored:
+The following object storage types are supported:
 
 * ``google`` for Google Cloud Storage, required configuration keys:
 

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -124,12 +124,11 @@ class CompressorThread(Thread, Compressor):
             compressed_filepath = None
         else:
             compressed_filepath = self.get_compressed_file_path(site, filetype, event["full_path"])
-            self.compress_filepath(
+            original_file_size, compressed_file_size = self.compress_filepath(
                 event["full_path"],
                 compressed_filepath,
                 compression_algorithm=self.compression_algorithm(),
                 rsa_public_key=rsa_public_key)
-            compressed_file_size = os.stat(compressed_filepath).st_size
         self.log.info("Compressed %d byte file: %r to %d bytes, took: %.3fs",
                       original_file_size, event['full_path'], compressed_file_size,
                       time.time() - start_time)

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -207,7 +207,7 @@ class Restore(object):
         metadata = self.storage.get_basebackup_file_to_fileobj(basebackup, tmp)
 
         rsa_private_key = None
-        if "encryption-key-id" in metadata:
+        if "encryption-key-id" in metadata and metadata["encryption-key-id"]:
             key_id = metadata["encryption-key-id"]
             site_keys = self.config["backup_sites"][site]["encryption_keys"]
             rsa_private_key = site_keys[key_id]["private"]

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -8,7 +8,7 @@ See LICENSE for details
 from .base import PGHoardTestCase
 from pghoard.common import create_connection_string
 from pghoard.pghoard import PGHoard
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import json
 import os
 
@@ -56,7 +56,13 @@ class TestPGHoard(PGHoardTestCase):
         self.pghoard.check_pg_versions_ok = self.real_check_pg_versions_ok
         super().teardown_method(method)
 
-    def test_handle_site(self):
+    @patch("subprocess.check_output")
+    def test_handle_site(self, subprocess_mock):
+        subprocess_mock.return_value = b"""\
+systemid|6222667313856416063
+timeline|1
+xlogpos|0/B003760
+dbname|"""
         self.pghoard.handle_site(self.test_site, self.config["backup_sites"][self.test_site])
         assert self.pghoard.receivexlogs == {}
         assert len(self.pghoard.time_of_last_backup_check) == 1


### PR DESCRIPTION
Previously we first stored the basebackup onto disk after which we
compressend and encrypted it. This meant we'd need roughly 2.5x
diskspace (1 copy in the running db, 1 as a cleartext tempfile and
~0.5x for the compressed encrypted copy).

This drops the requirement to roughly ~1.5x (1 running copy and a
second temporary compressed and encrypted one. Eventually we should
just create a stacked encryptor/compressor that would take a fp as
an input and give out a stacked file handle that you could read from
to write into an object storage.