### PR TITLE
version.py: use short_ver from Makefile if nothing else is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	$(RM) ../pghoard_* test-*.xml $(generated)
 
 pghoard/version.py: version.py
-	$(PYTHON) $^ $@
+	PGHOARD_SHORT_VER=$(short_ver) $(PYTHON) $^ $@
 
 deb: $(generated)
 	cp debian/changelog.in debian/changelog


### PR DESCRIPTION
This allows one to build the tarballs github serves for our tags.