### PR TITLE
setup.py: more changes for version and setup handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	$(RM) ../pghoard_* test-*.xml $(generated)
 
 pghoard/version.py: version.py
-	PGHOARD_SHORT_VER=$(short_ver) $(PYTHON) $^ $@
+	$(PYTHON) $^ $@
 
 deb: $(generated)
 	cp debian/changelog.in debian/changelog

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,19 @@ from setuptools import setup, find_packages
 import os
 import version
 
+
+readme_path = os.path.join(os.path.dirname(__file__), "README.rst")
+with open(readme_path, "r") as fp:
+    readme_text = fp.read()
+
+
+version_for_setup_py = version.get_project_version("pghoard/version.py")
+version_for_setup_py = ".dev".join(version_for_setup_py.split("-", 2)[:2])
+
+
 setup(
     name="pghoard",
-    version=version.get_project_version("pghoard/version.py"),
+    version=version_for_setup_py,
     zip_safe=False,
     packages=find_packages(exclude=["test"]),
     install_requires=[
@@ -31,7 +41,7 @@ setup(
     license="Apache 2.0",
     platforms=["POSIX", "MacOS"],
     description="PostgreSQL automatic backup/restore service daemon",
-    long_description=open("README.rst").read(),
+    long_description=readme_text,
     url="https://github.com/ohmu/pghoard/",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Instead of passing Makefile's version to setup.py in env when called from
make, read it from Makefile in version.py.  This allows us to use the
version even when we're calling setup.py directly without invoking make.

We'll also be careful about version numbers provided to setup.py: git tags
aren't accepted by pkg_resources so we'll just use the commits since tag as
a `.devN` tag.

Also make sure setup.py and version.py work correctly when called from a
working directory outside pghoard root.