### PR TITLE
basebackup streaming: read stderr and log it at debug level

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -4,7 +4,7 @@ pghoard - pg_basebackup handler
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
-from . common import set_subprocess_stdout_and_stderr_nonblocking, terminate_subprocess
+from .common import set_stream_nonblocking, set_subprocess_stdout_and_stderr_nonblocking, terminate_subprocess
 from dateutil.tz import tzlocal
 from pghoard.rohmu.compressor import Compressor
 from threading import Thread
@@ -88,8 +88,10 @@ class PGBaseBackup(Thread):
         c = Compressor()
         compression_algorithm = self.config.get("compression", {}).get("algorithm", "snappy")
         self.log.debug("Compressing basebackup directly to file: %r", basebackup_path)
+        set_stream_nonblocking(proc.stderr)
         original_input_size, compressed_file_size = c.compress_filepath(
             fileobj=proc.stdout,
+            stderr=proc.stderr,
             targetfilepath=basebackup_path,
             compression_algorithm=compression_algorithm,
             rsa_public_key=rsa_public_key)

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -159,10 +159,15 @@ def set_syslog_handler(syslog_address, syslog_facility, logger):
     return syslog_handler
 
 
+def set_stream_nonblocking(stream):
+    fd = stream.fileno()
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+
 def set_subprocess_stdout_and_stderr_nonblocking(proc):
-    for fd in [proc.stdout.fileno(), proc.stderr.fileno()]:
-        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-        fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+    set_stream_nonblocking(proc.stdout)
+    set_stream_nonblocking(proc.stderr)
 
 
 def terminate_subprocess(proc, timeout=0.1, log=None):

--- a/pghoard/rohmu/compressor.py
+++ b/pghoard/rohmu/compressor.py
@@ -115,7 +115,8 @@ class Compressor:
         return fsrc
 
     def compress_filepath(self, filepath=None, targetfilepath=None,
-                          compression_algorithm=None, rsa_public_key=None, fileobj=None):
+                          compression_algorithm=None, rsa_public_key=None,
+                          fileobj=None, stderr=None):
         start_time = time.monotonic()
         compressor = self.compressor(compression_algorithm)
 
@@ -141,6 +142,15 @@ class Compressor:
                     if compressed_data:
                         compressed_file_size += len(compressed_data)
                         output_file.write(compressed_data)
+
+                    # if fileobj is an actual process stderr can be passed
+                    # here as long as it's set to non-blocking mode in which
+                    # case we read from it to prevent the buffer from
+                    # filling up, and also log the output at debug level.
+                    if stderr:
+                        stderr_output = stderr.read()
+                        if stderr_output:
+                            self.log.debug(stderr_output)
 
                 compressed_data = (compressor.flush() or b"")
                 if encryptor:


### PR DESCRIPTION
This prevents the stderr buffer from filling, and lets us have a view of the
basebackup progress.