### PR TITLE
swift: segmented transfer support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -397,6 +397,9 @@ The following object storage types are supported:
 
   * ``auth_version`` - defaults to ``2.0`` for keystone, use ``1.0`` with
     Ceph Rados GW.
+  * ``segment_size`` - defaults to ``1024**3`` (1 gigabyte).  Objects larger
+    than this will be split into multiple segments on upload.  Many Swift
+    installations require large files (usually 5 gigabytes) to be segmented.
   * ``tenant_name``
 
 ``pg_basebackup_path`` (default ``/usr/bin/pg_basebackup``)

--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -92,7 +92,7 @@ class PGBaseBackup(Thread):
         original_input_size, compressed_file_size = c.compress_filepath(
             fileobj=proc.stdout,
             stderr=proc.stderr,
-            targetfilepath=basebackup_path,
+            compressed_filepath=basebackup_path,
             compression_algorithm=compression_algorithm,
             rsa_public_key=rsa_public_key)
         return original_input_size, compressed_file_size, {"compression-algorithm": compression_algorithm,

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -220,18 +220,14 @@ def get_object_storage_config(config, site):
     except KeyError:
         # fall back to `local` driver at `backup_location` if set
         if not config.get("backup_location"):
-            return None, None
+            return None
         storage_config = {
             "directory": config["backup_location"],
+            "storage_type": "local",
         }
-        storage_type = "local"
-    else:
-        storage_config = storage_config.copy()
-        try:
-            storage_type = storage_config.pop("storage_type")
-        except KeyError:
-            raise InvalidConfigurationError("storage_type not defined in site {!r} object_storage".format(site))
-    return storage_type, storage_config
+    if "storage_type" not in storage_config:
+        raise InvalidConfigurationError("storage_type not defined in site {!r} object_storage".format(site))
+    return storage_config
 
 
 def create_alert_file(config, filename):

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -239,8 +239,8 @@ class PGHoard(object):
     def get_remote_basebackups_info(self, site):
         storage = self.site_transfers.get(site)
         if not storage:
-            storage_type, storage_config = get_object_storage_config(self.config, site)
-            storage = get_transfer(storage_type, storage_config)
+            storage_config = get_object_storage_config(self.config, site)
+            storage = get_transfer(storage_config)
             self.site_transfers[site] = storage
 
         results = storage.list_path(os.path.join(self.config.get("path_prefix", ""),

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -127,8 +127,8 @@ class Restore(object):
         self.storage.show_basebackup_list()
 
     def _get_object_storage(self, site, pgdata):
-        storage_type, storage_config = get_object_storage_config(self.config, site)
-        storage = get_transfer(storage_type, storage_config)
+        storage_config = get_object_storage_config(self.config, site)
+        storage = get_transfer(storage_config)
         return ObjectStore(storage, self.config.get("path_prefix", ""), site, pgdata)
 
     def list_basebackups(self, arg):

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -210,8 +210,8 @@ class Restore(object):
         metadata = self.storage.get_basebackup_file_to_fileobj(basebackup, tmp)
 
         rsa_private_key = None
-        if "encryption-key-id" in metadata and metadata["encryption-key-id"]:
-            key_id = metadata["encryption-key-id"]
+        key_id = metadata.get("encryption-key-id")
+        if key_id:
             site_keys = self.config["backup_sites"][site]["encryption_keys"]
             rsa_private_key = site_keys[key_id]["private"]
 

--- a/pghoard/rohmu/__init__.py
+++ b/pghoard/rohmu/__init__.py
@@ -7,7 +7,12 @@ See LICENSE for details
 from . errors import InvalidConfigurationError
 
 
-def get_transfer(storage_type, storage_config):
+def get_transfer(storage_config, *, storage_type=None):
+    # TODO: drop storage_type from the function signature, always read it from the config
+    if "storage_type" in storage_config:
+        storage_config = storage_config.copy()
+        storage_type = storage_config.pop("storage_type")
+
     if storage_type == "azure":
         from .object_storage.azure import AzureTransfer
         return AzureTransfer(**storage_config)

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -97,8 +97,17 @@ class LocalTransfer(BaseTransfer):
 
     def _save_metadata(self, target_path, metadata):
         metadata_path = target_path + ".metadata"
+        # metadata is always a string: string mapping
+        if not metadata:
+            metadata = {}
+        else:
+            metadata = {
+                str(k): str(v)
+                for k, v in metadata.items()
+                if v is not None
+            }
         with open(metadata_path, "w") as fp:
-            json.dump(metadata or {}, fp)
+            json.dump(metadata, fp)
 
     def store_file_from_memory(self, key, memstring, metadata=None):
         target_path = self.format_key_for_backend(key.strip("/"))

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -43,8 +43,8 @@ class TransferAgent(Thread):
     def get_object_storage(self, site_name):
         storage = self.site_transfers.get(site_name)
         if not storage:
-            storage_type, storage_config = get_object_storage_config(self.config, site_name)
-            storage = get_transfer(storage_type, storage_config)
+            storage_config = get_object_storage_config(self.config, site_name)
+            storage = get_transfer(storage_config)
             self.site_transfers[site_name] = storage
 
         return storage

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -95,8 +95,8 @@ def _test_storage(st, driver, tmpdir):
         # test LocalFileIsRemoteFileError for local storage
         target_file = os.path.join(st.prefix, "test1/x1")
         with pytest.raises(errors.LocalFileIsRemoteFileError):
-            st.store_file_from_disk("test1/x1", target_file, {"lfirfe": True})
-        assert st.get_contents_to_string("test1/x1") == (b"1", {"lfirfe": True})
+            st.store_file_from_disk("test1/x1", target_file, {"local": True})
+        assert st.get_contents_to_string("test1/x1") == (b"1", {"local": "True"})
 
         with pytest.raises(errors.LocalFileIsRemoteFileError):
             st.get_contents_to_file("test1/x1", target_file)


### PR DESCRIPTION
Many Swift implementations require objects > 5 gigabytes to be segmented so
implement segmenting in the Swift driver with a default segment size of 1
gigabyte.  Smaller files are uploaded as before, but larger files are split
into 1 gigabyte chunks by default.