### PR TITLE
postgres_command: ignore backup label archive requests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,12 +2,13 @@ pghoard 1.2.0 (2016-XX-XX)
 ==========================
 
 * Support for Python 3.3
+* Ignore requests to archive backup labels
 * Creating new basebackups by timer can be disabled entirely for a site by
   removing the basebackup_interval_hours option or setting it to a null
   value
 * Trim log format when logging to journal under systemd
 * Emit a warning when running under systemd without python-systemd installed
-* Test improvements
+* Test and logging improvements
 
 pghoard 1.1.0 (2016-04-05)
 ==========================

--- a/pghoard/postgres_command.py
+++ b/pghoard/postgres_command.py
@@ -54,6 +54,9 @@ def http_request(host, port, method, path, headers=None):
 
 
 def archive_command(site, xlog, host=PGHOARD_HOST, port=PGHOARD_PORT):
+    if xlog.endswith(".backup"):
+        print("Ignoring request to archive backup label {!r}: PGHoard does not use them".format(xlog))
+        return
     status = http_request(host, port, "PUT", "/{}/archive/{}".format(site, xlog))
     if status == 201:
         return

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -239,11 +239,16 @@ class TestWebServer(object):
         backup_xlog_path = os.path.join(pghoard.config["backup_location"], pghoard.test_site, bl_file)
         with open(xlog_path, "w") as fp:
             fp.write("jee")
+        # backup labels are ignored - archiving returns success but file won't appear on disk
+        archive_command(host="127.0.0.1", port=pghoard.config["http_port"],
+                        site=pghoard.test_site, xlog=bl_label)
+        assert not os.path.exists(backup_xlog_path)
+        # any other files raise an error
         with pytest.raises(postgres_command.PGCError) as excinfo:
             archive_command(host="127.0.0.1", port=pghoard.config["http_port"],
-                            site=pghoard.test_site, xlog=bl_label)
+                            site=pghoard.test_site, xlog=bl_label + ".x")
         assert excinfo.value.exit_code == postgres_command.EXIT_ARCHIVE_FAIL
-        assert not os.path.exists(backup_xlog_path)
+        assert not os.path.exists(backup_xlog_path + ".x")
 
     def test_get_invalid(self, pghoard, tmpdir):
         ne_xlog_seg = "0000FFFF0000000C000000FE"


### PR DESCRIPTION
PGHoard does not use backup labels, but currently PG tried to archive them
through PGHoard whenever it was in archive mode which would hang
indefinitely.