### PR TITLE
s3: Add support for multipart uploads to AWS S3 buckets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ pghoard 1.2.0 (2016-XX-XX)
 * Trim log format when logging to journal under systemd
 * Emit a warning when running under systemd without python-systemd installed
 * Test and logging improvements, including support for proper use of syslog
+* s3 Support multipart uploads for greater network error resiliency
 
 pghoard 1.1.0 (2016-04-05)
 ==========================


### PR DESCRIPTION
For files larger than 100MB we start splitting transfers into 100MB
upload chunks. The idea is to gain resiliency in the face of network
errors when uploading large files.