### PR TITLE
compressor: Make LZMA compression level configurable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+pghoard 1.3.0 (2016-xx-xx)
+==========================
+
+* Make LZMA compression level configurable
+
 pghoard 1.2.0 (2016-04-28)
 ==========================
 

--- a/README.rst
+++ b/README.rst
@@ -49,10 +49,10 @@ With both modes of operations ``pghoard`` creates basebackups using
 pg_basebackup that is run against the database in question.
 
 ``pghoard`` compresses the received WAL logs and basebackups with Snappy (default)
-or LZMA (level 0) in order to ensure good compression speed and relatively small
-backup size. For performance critical applications it is recommended to test
-both compression algorithms to find the most suitable trade-off for the
-particular use-case (snappy is much faster but yields larger compressed files).
+or LZMA (configurable, level 0 by default) in order to ensure good compression speed
+and relatively smallbackup size. For performance critical applications it is
+recommended to test both compression algorithms to find the most suitable trade-off
+for the particular use-case (snappy is much faster but yields larger compressed files).
 
 Optionally, ``pghoard`` can encrypt backed up data at rest. Each individual
 file is encrypted and authenticated with file specific keys. The file
@@ -501,7 +501,8 @@ Determines syslog log facility. (requires syslog to be true as well)
 * ``compression`` WAL/basebackup compression parameters
 
  * ``algorithm`` default ``"snappy"`` if available, otherwise ``"lzma"``
- * ``thread_count`` (default ``5``) number of parallel compression threads
+ * ``level`` default ``"0"`` compression level for ``"lzma"`` compression
+* ``thread_count`` (default ``5``) number of parallel compression threads
 
 * ``transfer`` WAL/basebackup transfer parameters
 

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -114,6 +114,7 @@ class CompressorThread(Thread, Compressor):
             original_file_size, compressed_blob = self.compress_filepath_to_memory(
                 filepath=event["full_path"],
                 compression_algorithm=self.config["compression"]["algorithm"],
+                compression_level=self.config["compression"]["level"],
                 rsa_public_key=rsa_public_key)
             compressed_file_size = len(compressed_blob)
             compressed_filepath = None
@@ -124,6 +125,7 @@ class CompressorThread(Thread, Compressor):
                 filepath=event["full_path"],
                 compressed_filepath=compressed_filepath,
                 compression_algorithm=self.config["compression"]["algorithm"],
+                compression_level=self.config["compression"]["level"],
                 rsa_public_key=rsa_public_key)
 
         if event.get("delete_file_after_compression", True):
@@ -133,6 +135,7 @@ class CompressorThread(Thread, Compressor):
         metadata.update({
             "pg-version": self.config["backup_sites"][site].get("pg_version", 90500),
             "compression-algorithm": self.config["compression"]["algorithm"],
+            "compression-level": self.config["compression"]["level"],
             "original-file-size": original_file_size,
         })
         if encryption_key_id:

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -48,6 +48,7 @@ def set_config_defaults(config, *, check_commands=True):
         config["compression"].setdefault("algorithm", "snappy")
     else:
         config["compression"].setdefault("algorithm", "lzma")
+    config["compression"].setdefault("level", 0)
 
     # defaults for sites
     config.setdefault("backup_sites", {})

--- a/pghoard/rohmu/compressor.py
+++ b/pghoard/rohmu/compressor.py
@@ -61,9 +61,9 @@ class Compressor:
     def __init__(self):
         self.log = logging.getLogger("rohmu.Compressor")
 
-    def compressor(self, compression_algorithm):
+    def compressor(self, compression_algorithm, compression_level):
         if compression_algorithm == "lzma":
-            return lzma.LZMACompressor(preset=0)
+            return lzma.LZMACompressor(preset=compression_level)
         elif compression_algorithm == "snappy":
             if not snappy:
                 raise MissingLibraryError("python-snappy is required when using snappy compression")
@@ -115,12 +115,12 @@ class Compressor:
         return fsrc
 
     def compress_filepath(self, filepath=None, compressed_filepath=None,
-                          compression_algorithm=None, rsa_public_key=None,
-                          fileobj=None, stderr=None):
+                          compression_algorithm=None, compression_level=0,
+                          rsa_public_key=None, fileobj=None, stderr=None):
         start_time = time.monotonic()
         action = "Compressed"
 
-        compressor = self.compressor(compression_algorithm)
+        compressor = self.compressor(compression_algorithm, compression_level)
         encryptor = None
 
         compressed_file_size = 0
@@ -181,7 +181,7 @@ class Compressor:
                       time.monotonic() - start_time)
         return original_input_size, compressed_file_size
 
-    def compress_filepath_to_memory(self, filepath, compression_algorithm, rsa_public_key=None):
+    def compress_filepath_to_memory(self, filepath, compression_algorithm, compression_level=0, rsa_public_key=None):
         # This is meant to be used for smallish files, ie WAL and timeline files
         start_time = time.monotonic()
         action = "Compressed"
@@ -189,7 +189,7 @@ class Compressor:
             data = input_file.read()
         original_input_size = len(data)
 
-        compressor = self.compressor(compression_algorithm)
+        compressor = self.compressor(compression_algorithm, compression_level)
         compressed_data = compressor.compress(data)
         compressed_data += (compressor.flush() or b"")  # snappy flush() is a stub
         if rsa_public_key:

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -107,6 +107,7 @@ class Compression(PGHoardTestCase):
             "local_path": self.random_file_path.replace(self.incoming_path, self.handled_path),
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "original-file-size": self.random_file_size,
                 "pg-version": 90500,
             },
@@ -130,6 +131,7 @@ class Compression(PGHoardTestCase):
             "local_path": self.random_file_path,
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "original-file-size": self.random_file_size,
                 "pg-version": 90500,
             },
@@ -157,6 +159,7 @@ class Compression(PGHoardTestCase):
             "local_path": self.random_file_path,
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "encryption-key-id": "testkey",
                 "original-file-size": self.random_file_size,
                 "pg-version": 90500,
@@ -185,6 +188,7 @@ class Compression(PGHoardTestCase):
             "local_path": self.zero_file_path,
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "original-file-size": self.zero_file_size,
                 "pg-version": 90500,
             },
@@ -205,6 +209,7 @@ class Compression(PGHoardTestCase):
             "local_path": local_filepath,
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "original-file-size": self.random_file_size,
                 "pg-version": 90500,
             },
@@ -220,6 +225,7 @@ class Compression(PGHoardTestCase):
         _, blob = self.compressor.compress_filepath_to_memory(
             self.random_file_path,
             compression_algorithm=self.config["compression"]["algorithm"],
+            compression_level=self.config["compression"]["level"],
             rsa_public_key=CONSTANT_TEST_RSA_PUBLIC_KEY)
         callback_queue = Queue()
         local_filepath = os.path.join(self.temp_dir, "00000001000000000000000E")
@@ -230,6 +236,7 @@ class Compression(PGHoardTestCase):
             "local_path": local_filepath,
             "metadata": {
                 "compression-algorithm": self.algorithm,
+                "compression-level": 0,
                 "encryption-key-id": "testkey",
                 "original-file-size": self.random_file_size,
                 "pg-version": 90500,


### PR DESCRIPTION
Previously it was hardcoded to zero, default to that but allow
users to override the compression level.