### PR TITLE
Remove default value from basebackup_interval_hours

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -56,7 +56,7 @@ def set_config_defaults(config, *, check_commands=True):
         site_config.setdefault("active", True)
         site_config.setdefault("active_backup_mode", "pg_receivexlog")
         site_config.setdefault("basebackup_count", 2)
-        site_config.setdefault("basebackup_interval_hours", 24)
+        site_config.setdefault("basebackup_interval_hours", None)
         site_config.setdefault("encryption_key_id", None)
         site_config.setdefault("object_storage", None)
         site_config.setdefault("pg_xlog_directory", "/var/lib/pgsql/data/pg_xlog")


### PR DESCRIPTION
Doc says that basebackup_interval_hours has no default value.