### PR TITLE
basebackup: When using stream compression store pg-version into metadata

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -175,6 +175,7 @@ class PGBaseBackup(Thread):
                     "start-time": start_time,
                     "start-wal-segment": self.start_wal_segment,
                     "original-file-size": original_input_size,
+                    "pg-version": self.pg_version_server,
                 },
                 "site": self.site,
                 "type": "UPLOAD",

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -59,9 +59,11 @@ LABEL: pg_basebackup base backup
             "list-basebackups",
             "--config", pghoard.config_path,
             "--site", pghoard.test_site,
+            "--verbose",
         ])
         out, _ = capsys.readouterr()
         assert pghoard.test_site in out
+        assert "pg-version" in out
         # try downloading it
         backup_out = str(tmpdir.join("test-restore"))
         os.makedirs(backup_out)


### PR DESCRIPTION
Also enhance existing unittest for stream-compression to check
for the its existence.

This is needed since stream-compression bypasses Compressor where
we usually set the pg-version.