### PR TITLE
startup_walk_for_missed_files: handle compressed and uncompressed files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ pghoard 1.3.0 (2016-xx-xx)
 ==========================
 
 * Make LZMA compression level configurable
+* Fix unprocessed file handling in receivexlog mode after restart
 * Miscellaneous bug fixes
 
 pghoard 1.2.0 (2016-04-28)


### PR DESCRIPTION
Previously startup_walk_for_missed_files didn't consider compressed and
uncompressed incoming files (ie files received by receivexlog) separately
and tried to recompress already compressed files and left uncompressed files
alone.