### PR TITLE
wal: add 9.6 beta1 wal magic number

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 pghoard 1.3.0 (2016-xx-xx)
 ==========================
 
+* Support for PostgreSQL 9.6
 * Make LZMA compression level configurable
 * Fix unprocessed file handling in receivexlog mode after restart
 * Miscellaneous bug fixes
@@ -41,6 +42,7 @@ pghoard 1.1.0 (2016-04-05)
 pghoard 1.0.0 (2016-03-16)
 ==========================
 
+* Support for PostgreSQL 9.3 - 9.5
 * Support compressing basebackups on the fly
 * Add archive_sync command to sync archive / check archive integrity
 * Support different recovery_targets

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -18,6 +18,7 @@ WAL_MAGIC = {
     0xD075: 90300,
     0xD07E: 90400,
     0xD087: 90500,
+    0xD091: 90600,
 }
 WAL_MAGIC_BY_VERSION = {value: key for key, value in WAL_MAGIC.items()}
 


### PR DESCRIPTION
We need to recognize the magic number from WAL to archive it.