### PR TITLE
wal: Ensure that the pg_version given is an integer for comparison

### DIFF
--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -59,7 +59,7 @@ def get_previous_wal_on_same_timeline(seg, log, pg_version):
     if seg == 0:
         log -= 1
         # Pre 9.3 PG versions have a gap in their WAL ranges
-        if pg_version and pg_version < 90300:
+        if pg_version and int(pg_version) < 90300:
             seg = 0xFE
         else:
             seg = 0xFF


### PR DESCRIPTION
Since we have to store the pg_version in the object store file
metadata as a string, ensure it's an integer.