### PR TITLE
walreceiver: Add experimental support for replicating WALs via PG rep…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,9 @@ pghoard X.X.X (2016-XX-XX)
 * Make sure object storage modules are importable when reading configuration
   instead of only checking it when they are used
 * Improved PostgreSQL 9.2, 9.6 beta and Python 3.3 compatibility
+* Experimental support for new mode walreceiver which uses the PostgreSQL
+  replication protocol. Much faster and less resource consuming WAL replication
+  than when using active_backup_mode: pg_receivexlog.
 
 pghoard 1.3.0 (2016-05-30)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ PGHoard |BuildStatus|_
 Features:
 
 * Automatic periodic basebackups
-* Automatic transaction log (WAL/xlog) backups (using either ``pg_receivexlog``
-  or ``archive_command``)
+* Automatic transaction log (WAL/xlog) backups (using either ``pg_receivexlog``,
+  ``archive_command`` or experimental PG native replication protocol support with ``walreceiver``)
 * Cloud object storage support (AWS S3, Google Cloud, OpenStack Swift, Azure, Ceph)
 * Backup restoration directly from object storage, compressed and encrypted
 * Point-in-time-recovery (PITR)
@@ -44,7 +44,9 @@ PGHoard supports multiple operating models.  The basic mode where you have a
 separate backup machine, ``pghoard`` can simply connect with
 ``pg_receivexlog`` to receive WAL files from the database as they're
 written.  Another model is to use ``pghoard_postgres_command`` as a
-PostgreSQL ``archive_command``.
+PostgreSQL ``archive_command``. There is also experimental support for PGHoard to
+use PostgreSQL's native replication protocol with the experimental
+``walreceiver`` mode.
 
 With both modes of operations PGHoard creates periodic basebackups using
 ``pg_basebackup`` that is run against the database in question.
@@ -179,7 +181,7 @@ installation.
 0.  Make sure PostgreSQL is configured to allow WAL archival and retrieval.
     ``postgresql.conf`` should have ``wal_level`` set to ``archive`` or
     higher and ``max_wal_senders`` set to at least ``1`` (``archive_command`` mode)
-    or at least ``2`` (``pg_receivexlog`` mode), for example::
+    or at least ``2`` (``pg_receivexlog`` and ``walreceiver`` modes), for example::
 
         wal_level = archive
         max_wal_senders = 4
@@ -354,7 +356,11 @@ of new backups and to stop the deletion of old ones.
 Can be either ``pg_receivexlog`` or ``archive_command``. If set to
 ``pg_receivexlog``, ``pghoard`` will start up a ``pg_receivexlog`` process to be
 run against the database server.  If ``archive_command`` is set, we rely on the
-user setting the correct ``archive_command`` in ``postgresql.conf``.
+user setting the correct ``archive_command`` in
+``postgresql.conf``. You can also set this to the experimental ``walreceiver`` mode
+whereby pghoard will start communicating directly with PostgreSQL
+through the replication protocol. (Note requires an unreleased version
+of psycopg2 library)
 
 ``alert_file_dir`` (default ``os.getcwd()``)
 

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -5,8 +5,8 @@ Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
 from pghoard import pgutil
-from pghoard.rohmu.compat import suppress
 from pghoard.rohmu.errors import Error, InvalidConfigurationError
+import contextlib
 import datetime
 import fcntl
 import json
@@ -16,6 +16,16 @@ import re
 import tempfile
 import time
 
+try:
+    from contextlib import suppress
+except ImportError:
+    # For pre Python3.4
+    @contextlib.contextmanager
+    def suppress(*exceptions):
+        try:
+            yield
+        except exceptions:
+            pass
 
 LOG = logging.getLogger("pghoard.common")
 

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -72,6 +72,21 @@ def name_for_tli_log_seg(tli, log, seg):
     return "{:08X}{:08X}{:08X}".format(tli, log, seg)
 
 
+def convert_integer_to_lsn(value):
+    log = value >> 32
+    pos = value & 0xFFFFFFFF
+    seg = pos // XLOG_SEG_SIZE
+    return log, pos, seg
+
+
+def get_lsn_from_start_of_wal_file(lsn):
+    log_hex, seg_hex = lsn.split("/", 1)
+    log = int(log_hex, 16)
+    seg = int(seg_hex, 16) >> 24
+    pos = seg * XLOG_SEG_SIZE
+    return "{:X}/{:X}".format(log, pos)
+
+
 def lsn_from_name(name):
     _, log, seg = name_to_tli_log_seg(name)
     pos = seg * XLOG_SEG_SIZE

--- a/pghoard/walreceiver.py
+++ b/pghoard/walreceiver.py
@@ -1,0 +1,205 @@
+"""
+pghoard - walreceiver
+
+Copyright (c) 2016 Ohmu Ltd
+See LICENSE for details
+"""
+from io import BytesIO
+from pghoard.common import suppress
+from pghoard.wal import get_lsn_from_start_of_wal_file, convert_integer_to_lsn, name_for_tli_log_seg, XLOG_SEG_SIZE
+from psycopg2.extras import PhysicalReplicationConnection, REPLICATION_PHYSICAL  # pylint: disable=no-name-in-module
+from queue import Empty, Queue
+from threading import Thread
+import datetime
+import logging
+import os
+import psycopg2
+import select
+
+
+KEEPALIVE_INTERVAL = 10.0
+
+
+class WALReceiver(Thread):
+    def __init__(self, config, connection_string, compression_queue, replication_slot, pg_version_server, site,
+                 last_flushed_lsn=None, stats=None):
+        super().__init__()
+        self.log = logging.getLogger("WALReceiver")
+        self.running = True
+        self.config = config
+        self.pg_version_server = pg_version_server
+        self.compression_queue = compression_queue
+        self.replication_slot = replication_slot
+        self.completed_wal_segments = set()
+        self.dsn = connection_string
+        self.site = site
+        self.conn = None
+        self.c = None
+        self.buffer = BytesIO()
+        self.latest_wal = None
+        self.latest_wal_start = None
+        self.latest_activity = datetime.datetime.utcnow()
+        self.callbacks = {}
+        self.last_flushed_lsn = last_flushed_lsn
+        self.stats = stats
+        self.log.info("WALReceiver initialized with replication_slot: %r, last_flushed_lsn: %r",
+                      self.replication_slot, last_flushed_lsn)
+
+    def _init_cursor(self):
+        self.conn = psycopg2.connect(self.dsn, connection_factory=PhysicalReplicationConnection)
+        self.c = self.conn.cursor()
+
+    def create_replication_slot(self):
+        try:
+            self.c.create_replication_slot(self.replication_slot, slot_type=REPLICATION_PHYSICAL)
+        except psycopg2.ProgrammingError as ex:
+            if "already exists" in ex.pgerror:
+                return
+            raise
+
+    def fetch_timeline_history_files(self, max_timeline):
+        """Copy all timeline history files found on the server without
+           checking if we have them or not. The history files are very small
+           so reuploading them should not matter."""
+        while max_timeline > 1:
+            self.c.execute("TIMELINE_HISTORY {}".format(max_timeline))
+            timeline_history = self.c.fetchone()
+            history_filename = timeline_history[0]
+            history_data = timeline_history[1].tobytes()
+            self.log.debug("Received timeline history: %s for timeline %r",
+                           history_filename, max_timeline)
+
+            compression_event = {
+                "type": "CLOSE_WRITE",
+                "compress_to_memory": True,
+                "delete_file_after_compression": False,
+                "input_data": BytesIO(history_data),
+                "full_path": history_filename,
+                "site": self.site,
+            }
+            self.compression_queue.put(compression_event)
+            max_timeline -= 1
+
+    def start_replication(self):
+        # TODO: We might want to read from the position where the pghoard slot is
+        # when restarting pghoard, instead of always reading from current position
+        # at the time of starting replication. The slot position is unfortunately
+        # not available on the replication protocol side and would have to be queried
+        # through a regular PG connection. Currently we workaround this by reading
+        # it back from pghoard's state file.
+        self.c.execute("IDENTIFY_SYSTEM")
+        identify_system = self.c.fetchone()
+        self.log.debug("System identified itself as: %r", identify_system)
+        timeline = identify_system[1]
+        self.fetch_timeline_history_files(timeline)
+
+        # Figure out the LSN we should try to replicate from
+        if self.last_flushed_lsn:
+            log, pos, _ = convert_integer_to_lsn(self.last_flushed_lsn)
+            lsn = "{:X}/{:X}".format(log, pos)
+        else:
+            lsn = get_lsn_from_start_of_wal_file(identify_system[2])
+
+        self.log.info("Starting replication from %r, timeline: %r with slot: %r",
+                      lsn, timeline, self.replication_slot)
+        if self.replication_slot:
+            self.c.start_replication(
+                slot_name=self.replication_slot,
+                slot_type=REPLICATION_PHYSICAL,
+                start_lsn=lsn,
+                timeline=timeline)
+        else:
+            self.c.start_replication(
+                start_lsn=lsn,
+                timeline=timeline)
+        return timeline
+
+    def switch_xlog(self):
+        self.log.debug("Switching xlog from %r amount of data: %r",
+                       self.latest_wal, self.buffer.tell())
+
+        self.buffer.seek(0)
+        wal_data = BytesIO(self.buffer.read(XLOG_SEG_SIZE))
+        wal_data.seek(0, os.SEEK_END)
+        padding = XLOG_SEG_SIZE - wal_data.tell()
+        # Pad with 0s up to XLOG_SEG_SIZE
+        wal_data.write(padding * b"\0")
+        wal_data.seek(0)
+        callback_queue = Queue()
+        self.callbacks[self.latest_wal_start] = callback_queue
+
+        compression_event = {
+            "type": "CLOSE_WRITE",
+            "callback_queue": callback_queue,
+            "compress_to_memory": True,
+            "delete_file_after_compression": False,
+            "input_data": wal_data,
+            "full_path": self.latest_wal,
+            "site": self.site,
+        }
+        self.latest_wal = None
+        self.compression_queue.put(compression_event)
+
+        rest_of_data = self.buffer.read()
+        assert len(rest_of_data) == 0
+        self.buffer = BytesIO(rest_of_data)
+        self.buffer.seek(0, os.SEEK_END)
+
+    def run(self):
+        self._init_cursor()
+        if self.replication_slot:
+            self.create_replication_slot()
+        timeline = self.start_replication()
+        while self.running:
+            wal_name = None
+            try:
+                msg = self.c.read_message()
+            except psycopg2.DatabaseError as ex:
+                self.log.exception("Unexpected exception in reading walreceiver msg")
+                self.stats.unexpected_exception(ex, where="walreceiver_run")
+                continue
+            self.log.debug("replication_msg: %r, buffer: %r/%r",
+                           msg, self.buffer.tell(), XLOG_SEG_SIZE)
+            if msg:
+                self.latest_activity = datetime.datetime.utcnow()
+                log, _, seg = convert_integer_to_lsn(msg.data_start)
+                wal_name = name_for_tli_log_seg(timeline, log, seg)
+
+                if not self.latest_wal:
+                    self.latest_wal_start = msg.data_start
+                    self.latest_wal = wal_name
+                self.buffer.write(msg.payload)
+
+                # TODO: Calculate end pos and transmit that?
+                msg.cursor.send_feedback(write_lsn=msg.data_start)
+
+            if wal_name and self.latest_wal != wal_name or self.buffer.tell() >= XLOG_SEG_SIZE:
+                self.switch_xlog()
+
+            for wal_start, queue in self.callbacks.items():
+                with suppress(Empty):
+                    transfer_result = queue.get_nowait()
+                    self.log.debug("Transfer result: %r", transfer_result)
+                    self.completed_wal_segments.add(wal_start)
+
+            for completed_lsn in sorted(self.completed_wal_segments):
+                self.callbacks.pop(completed_lsn)
+                if self.callbacks:
+                    if completed_lsn > min(self.callbacks):
+                        pass  # Do nothing since a smaller lsn is still being transferred
+                    else:  # Earlier lsn than earlist on-going transfer, just advance flush_lsn
+                        self.c.send_feedback(flush_lsn=completed_lsn)
+                        self.completed_wal_segments.discard(completed_lsn)
+                        self.last_flushed_lsn = completed_lsn
+                        self.log.debug("Sent flush_lsn feedback as: %r", self.last_flushed_lsn)
+                else:  # No on-going transfer, just advance flush_lsn
+                    self.c.send_feedback(flush_lsn=completed_lsn)
+                    self.completed_wal_segments.discard(completed_lsn)
+                    self.last_flushed_lsn = completed_lsn
+                    self.log.debug("Sent flush_lsn feedback as: %r", self.last_flushed_lsn)
+
+            if not msg:
+                timeout = KEEPALIVE_INTERVAL - (datetime.datetime.now() - self.c.io_timestamp).total_seconds()
+                with suppress(InterruptedError):
+                    if not any(select.select([self.c], [], [], max(0, timeout))):
+                        self.c.send_feedback()  # timing out, send keepalive

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,11 +102,18 @@ def db():
 @pytest.yield_fixture  # pylint: disable=redefined-outer-name
 def pghoard(db, tmpdir, request):  # pylint: disable=redefined-outer-name
     test_site = request.function.__name__
+
+    if os.environ.get("pghoard_test_walreceiver"):
+        active_backup_mode = "walreceiver"
+    else:
+        active_backup_mode = "pg_receivexlog"
+
     config = {
         "alert_file_dir": os.path.join(str(tmpdir), "alerts"),
         "backup_location": os.path.join(str(tmpdir), "backupspool"),
         "backup_sites": {
             test_site: {
+                "active_backup_mode": active_backup_mode,
                 "basebackup_count": 2,
                 "basebackup_interval_hours": 24,
                 "pg_bin_directory": db.pgbin,

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -53,7 +53,7 @@ timeline|1
 xlogpos|0/B003760
 dbname|"""
         self.pghoard.handle_site(self.test_site, self.config["backup_sites"][self.test_site])
-        assert len(self.pghoard.receivexlogs) == 1
+        assert len(self.pghoard.receivexlogs) == 1 or len(self.pghoard.walreceivers) == 1
         assert len(self.pghoard.time_of_last_backup_check) == 1
 
     def test_get_local_basebackups_info(self):
@@ -216,6 +216,7 @@ dbname|"""
             "transfer_agents": [{}] * thread_count,
             "pg_receivexlogs": {},
             "pg_basebackups": {},
+            "walreceivers": {},
         }
         assert empty_state == state
 


### PR DESCRIPTION
…lication protocol

You can now use "active_backup_mode": "walreceiver" in case you have a psycopg2
that supports the PostgreSQL replication protocol. At this time the support hasn't
been merged into psycopg2 master but can be found from:

https://github.com/psycopg/psycopg2/pull/322

The backup method "walreceiver" writes no extra WAL data to disk on the machine
taking the backup.

Before this when using pg_receivexlog mode pghoard first wrote the files uncompressed
on disk once and then compressed them and wrote them on disk again causing roughly
1.5x the size of WAL writes just so pghoard could back the files up.

We now also write the last flush_lsn position into pghoard state file and read
it back from there when creating a walreceiver so we can continue from the last
known position. Note that this will fail in case pghoard was shutdown uncleanly.
(kill -9 or such)