### PR TITLE
backup and restore: improve tar handling performance

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -12,6 +12,7 @@ from .common import (
     set_subprocess_stdout_and_stderr_nonblocking,
     terminate_subprocess,
 )
+from .patchedtarfile import tarfile
 from pghoard.rohmu import errors, rohmufile
 from pghoard.rohmu.compat import suppress
 from tempfile import NamedTemporaryFile
@@ -25,7 +26,6 @@ import os
 import psycopg2
 import select
 import subprocess
-import tarfile
 import time
 
 BASEBACKUP_NAME = "pghoard_base_backup"
@@ -225,7 +225,7 @@ class PGBaseBackup(Thread):
         return start_wal_segment, start_time
 
     def parse_backup_label_in_tar(self, basebackup_path):
-        with tarfile.open(basebackup_path) as tar:
+        with tarfile.TarFile(name=basebackup_path, mode="r") as tar:
             content = tar.extractfile("backup_label").read()  # pylint: disable=no-member
         return self.parse_backup_label(content)
 
@@ -384,7 +384,7 @@ class PGBaseBackup(Thread):
                                                compression_algorithm=compression_algorithm,
                                                compression_level=compression_level,
                                                rsa_public_key=rsa_public_key) as output_obj:
-                        with tarfile.open(fileobj=output_obj, mode="w|") as output_tar:
+                        with tarfile.TarFile(fileobj=output_obj, mode="w") as output_tar:
                             self.write_files_to_tar(pgdata=pgdata, tablespaces=tablespaces, tar=output_tar)
                         input_size = output_obj.tell()
 

--- a/pghoard/patchedtarfile.py
+++ b/pghoard/patchedtarfile.py
@@ -1,0 +1,38 @@
+# pghoard - tarfile's copyfileobj with bigger buffer size
+#
+# Code copied from https://github.com/python/cpython master on 2016-06-13
+# This code is under the Python license.
+
+from pghoard.rohmu import IO_BLOCK_SIZE as BUFSIZE
+import shutil
+import tarfile
+
+
+def copyfileobj(src, dst, length=None, exception=OSError):
+    """Copy length bytes from fileobj src to fileobj dst.
+       If length is None, copy the entire content.
+    """
+    if length == 0:
+        return
+    if length is None:
+        shutil.copyfileobj(src, dst)
+        return
+
+    # BUFSIZE = 16 * 1024
+    blocks, remainder = divmod(length, BUFSIZE)
+    # for b in range(blocks):
+    for _ in range(blocks):
+        buf = src.read(BUFSIZE)
+        if len(buf) < BUFSIZE:
+            raise exception("unexpected end of data")
+        dst.write(buf)
+
+    if remainder != 0:
+        buf = src.read(remainder)
+        if len(buf) < remainder:
+            raise exception("unexpected end of data")
+        dst.write(buf)
+    return
+
+
+tarfile.copyfileobj = copyfileobj


### PR DESCRIPTION
* Monkey-patch tarfile to increase buffer size for file copying from 16KiB
  to 2MiB
* Don't use "|" in mode when writing - it's really only useful when using
  tarfile's internal compression handling, and causes unnecessary extra
  buffering (in 10KiB buffers by default)
* When reading tar files (pghoard_restore get-basebackup) we need to use
  tarfile's stream buffer management until rohmu's SnappyFile interface
  supports buffering and seeks.  To make it less slow increase the buffer
  size to something reasonable