### PR TITLE
Fix statsd README typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -550,7 +550,7 @@ The value is a JSON object::
 
   {
       "host": "<statsd address>",
-      "port": "<statsd port>",
+      "port": <statsd port>,
       "tags": {
           "<tag>": "<value>"
       }


### PR DESCRIPTION
This fixes #134 
There are other ports (e.g `http_port`) in config that do not cast str value to integer.