### PR TITLE
Add support for DataDog statsd format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -543,24 +543,33 @@ all operations in parallel when a single backup site is used.
 
 ``statsd`` (default: disabled)
 
-Enables metrics sending to a statsd daemon that supports the StatsD /
-Telegraf syntax with tags.
+Enables metrics sending to a statsd daemon that supports Telegraf
+or DataDog syntax with tags.
 
 The value is a JSON object::
 
   {
       "host": "<statsd address>",
       "port": <statsd port>,
+      "format": "<statsd message format>",
       "tags": {
           "<tag>": "<value>"
       }
   }
 
-The ``tags`` setting can be used to enter optional tag values for the metrics.
+``format`` (default: ``"telegraf"``)
 
-Metrics sending follows the `Telegraf spec`_.
+Determines statsd message format. Following formats are supported:
+
+* ``telegraf`` `Telegraf spec`_
 
 .. _`Telegraf spec`: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
+
+* ``datadog`` `DataDog spec`_
+
+.. _`DataDog spec`: http://docs.datadoghq.com/guides/dogstatsd/#datagram-format
+
+The ``tags`` setting can be used to enter optional tag values for the metrics.
 
 ``syslog`` (default ``false``)
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -465,7 +465,7 @@ class PGHoard:
         # statsd settings may have changed
         stats = self.config.get("statsd", {})
         self.stats = statsd.StatsClient(host=stats.get("host"), port=stats.get("port"),
-                                        tags=stats.get("tags"))
+                                        tags=stats.get("tags"), message_format=stats.get("format"))
 
         self.log.debug("Loaded config: %r from: %r", self.config, self.config_path)
 


### PR DESCRIPTION
Small patch to add support for DataDog statsd format.
I also tried to use Telegraf format to send stats to Datadog, in general it works, but metric name was set based on tags, but tags are in python dict, so there is no strict order, sometimes it was: `pghoard.last_upload_age_type_basebackup_site_foo` next time `pghoard.last_upload_age_site_foo_type_basebackup`.