### PR TITLE
Check PATH for pg binaries in find_pg_binary

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -9,7 +9,7 @@ from pghoard.postgres_command import PGHOARD_HOST, PGHOARD_PORT
 from pghoard.rohmu import get_class_for_transfer
 from pghoard.rohmu.errors import InvalidConfigurationError
 from pghoard.rohmu.snappyfile import snappy
-from distutils.spawn import find_executable # pylint: disable=no-member
+from distutils.spawn import find_executable # pylint: disable=import-error,no-name-in-module
 import json
 import os
 import subprocess

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -9,7 +9,7 @@ from pghoard.postgres_command import PGHOARD_HOST, PGHOARD_PORT
 from pghoard.rohmu import get_class_for_transfer
 from pghoard.rohmu.errors import InvalidConfigurationError
 from pghoard.rohmu.snappyfile import snappy
-from distutils.spawn import find_executable
+from distutils.spawn import find_executable # pylint: disable=no-member
 import json
 import os
 import subprocess

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -9,7 +9,7 @@ from pghoard.postgres_command import PGHOARD_HOST, PGHOARD_PORT
 from pghoard.rohmu import get_class_for_transfer
 from pghoard.rohmu.errors import InvalidConfigurationError
 from pghoard.rohmu.snappyfile import snappy
-from distutils.spawn import find_executable # pylint: disable=import-error,no-name-in-module
+from distutils.spawn import find_executable  # pylint: disable=import-error,no-name-in-module
 import json
 import os
 import subprocess


### PR DESCRIPTION
Currently if postgres binaries are installed in /usr/local/bin they aren't found.  This patch uses the PATH to find them when necessary.
