### PR TITLE
Support S3 server-side encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *~
+/.cache
 /.coverage
 /.project
 /.pydevproject

--- a/README.rst
+++ b/README.rst
@@ -484,6 +484,10 @@ The following object storage types are supported:
  * ``region`` S3 region of the bucket
  * ``bucket_name`` name of the S3 bucket
 
+Optional keys for Amazon Web Services S3:
+
+ * ``encryption`` if True, use server-side encryption. Default is False.
+
 * ``s3`` for other S3 compatible services such as Ceph, required
   configuration keys:
 

--- a/README.rst
+++ b/README.rst
@@ -486,7 +486,7 @@ The following object storage types are supported:
 
 Optional keys for Amazon Web Services S3:
 
- * ``encryption`` if True, use server-side encryption. Default is False.
+ * ``encrypted`` if True, use server-side encryption. Default is False.
 
 * ``s3`` for other S3 compatible services such as Ceph, required
   configuration keys:

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -150,7 +150,7 @@ class S3Transfer(BaseTransfer):
         size = os.path.getsize(filepath)
         key = self.format_key_for_backend(key)
         metadata = self.sanitize_metadata(metadata)
-        if not multipart or size <= self.multipart_chunk_size:
+        if not multipart and size <= self.multipart_chunk_size:
             s3key = Key(self.bucket)
             s3key.key = key
             if metadata:

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -38,7 +38,8 @@ class S3Transfer(BaseTransfer):
                  host=None,
                  port=None,
                  is_secure=False,
-                 segment_size=MULTIPART_CHUNK_SIZE):
+                 segment_size=MULTIPART_CHUNK_SIZE,
+                 encrypted=False):
         super().__init__(prefix=prefix)
         self.region = region
         self.location = _location_for_region(region)
@@ -53,6 +54,7 @@ class S3Transfer(BaseTransfer):
                                                   aws_secret_access_key=aws_secret_access_key)
         self.bucket = self.get_or_create_bucket(self.bucket_name)
         self.multipart_chunk_size = segment_size
+        self.encrypted = encrypted
         self.log.debug("S3Transfer initialized")
 
     def get_metadata_for_key(self, key):

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -123,7 +123,7 @@ class S3Transfer(BaseTransfer):
         if metadata:
             for k, v in self.sanitize_metadata(metadata).items():
                 s3key.set_metadata(k, v)
-        s3key.set_contents_from_string(memstring, replace=True)
+        s3key.set_contents_from_string(memstring, replace=True, encrypt_key=self.encrypted)
 
     def _store_multipart_upload(self, mp, fp, part_num, filepath):
         attempt = 0
@@ -158,13 +158,15 @@ class S3Transfer(BaseTransfer):
             if metadata:
                 for k, v in metadata.items():
                     s3key.set_metadata(k, v)
-            s3key.set_contents_from_filename(filepath, replace=True)
+            s3key.set_contents_from_filename(filepath, replace=True,
+                                             encrypt_key=self.encrypted)
         else:
             start_of_multipart_upload = time.monotonic()
             chunks = math.ceil(size / self.multipart_chunk_size)
             self.log.debug("Starting to upload multipart file: %r, size: %r, chunks: %d",
                            key, size, chunks)
-            mp = self.bucket.initiate_multipart_upload(key, metadata=metadata)
+            mp = self.bucket.initiate_multipart_upload(key, metadata=metadata,
+                                                       encrypt_key=self.encrypted)
 
             with open(filepath, "rb") as fp:
                 part_num = 0

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -81,10 +81,13 @@ class S3Transfer(BaseTransfer):
         for item in self.bucket.list(path, "/"):
             if not hasattr(item, "last_modified"):
                 continue  # skip objects with no last_modified: not regular objects
+            name = self.format_key_from_backend(item.name)
+            if name == path:
+                continue  # skip the path itself
             result.append({
                 "last_modified": dateutil.parser.parse(item.last_modified),
                 "metadata": self._metadata_for_key(item.name),
-                "name": self.format_key_from_backend(item.name),
+                "name": name,
                 "size": item.size,
             })
         return result


### PR DESCRIPTION
This PR implements optional support for S3 server-side encryption. It also fixes the S3 tests which, as far as I can tell, currently do not work for two reasons:

1. The `bucket.list(path)` method includes the `path` itself in the response but the tests `assert` a length of the return value that only contains the keys added to the path. The implementation of `list_path` is updated to discard the element for `path`.
1. The test code to inject a failure into the S3 upload does not work. The `new_key` method isn't called during the upload. The test code also assumes a multipart upload will happen but the production code is using the non-multipart upload path. The `store_file_from_disk` implementation now always uses a multipart upload if the `multipart` argument is True. Otherwise there doesn't seem to be much point in having the `multipart` argument. The failure injection is now done with `mock.patch`.

One thing I'm not certain of is the status of `encrypt_key` support in Ceph, which I have no experience in.