### PR TITLE
S3 encryption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *~
+/.cache
 /.coverage
 /.project
 /.pydevproject

--- a/README.rst
+++ b/README.rst
@@ -487,6 +487,10 @@ The following object storage types are supported:
  * ``region`` S3 region of the bucket
  * ``bucket_name`` name of the S3 bucket
 
+Optional keys for Amazon Web Services S3:
+
+ * ``encrypted`` if True, use server-side encryption. Default is False.
+
 * ``s3`` for other S3 compatible services such as Ceph, required
   configuration keys:
 


### PR DESCRIPTION
This PR (a redo of #150) implements optional support for S3 server-side encryption. It also fixes the S3 tests which, as far as I can tell, currently do not work for two reasons:

1. The `bucket.list(path)` method includes the path itself in the response but the tests assert a length of the return value that only contains the keys added to the path. The implementation of `list_path` is updated to discard the element for path.
1. The test code to inject a failure into the S3 upload does not work. The `new_key` method isn't called during the upload. The test code also assumes a multipart upload will happen but the production code is using the non-multipart upload path. The `store_file_from_disk` implementation now always uses a multipart upload if the multipart argument is True. Otherwise there doesn't seem to be much point in having the multipart argument. The failure injection is now done with mock.patch.

One thing I'm not certain of is the status of encrypt_key support in Ceph, which I have no experience in.