### PR TITLE
azure: Make Azure support work with latest azure-storage-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
 
 install:
-  - "pip install boto cryptography flake8 httplib2 mock psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests"
+  - "pip install boto cryptography flake8 httplib2 mock psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
 
 script:
   - "make pylint"

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ pghoard X.X.X (2016-XX-XX)
   versions require the pgespresso extension to take backups of replicas
   using the `local-tar` method, the pg_basebackup utilizing (default)
   methods have always supported backups of replicas.
+* Upgrade Azure object storage work with the latest python-azure-storage.
+  The previous version of the Azure storage driver no longer worked with
+  the latest version of python-azure-storage driver.
 
 
 pghoard 1.4.0 (2016-07-22)

--- a/README.rst
+++ b/README.rst
@@ -502,7 +502,7 @@ The following object storage types are supported:
 
  * ``account_name`` for the name of the Azure Storage account
  * ``account_key`` for the secret key of the Azure Storage account
- * ``container_name`` for the name of Azure Storage container used to store
+ * ``bucket_name`` for the name of Azure Storage container used to store
    objects
 
 * ``swift`` for OpenStack Swift, required configuration keys:

--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -4,88 +4,115 @@ rohmu - azure object store interface
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
-import dateutil.parser
-import time
-from azure.storage import BlobService  # pylint: disable=no-name-in-module, import-error
+from azure.storage.blob import BlockBlobService
+from azure.storage.blob.models import BlobPrefix
 from .base import BaseTransfer
+from ..errors import FileNotFoundFromStorageError
+import azure.common
+import time
 
 
 class AzureTransfer(BaseTransfer):
-    def __init__(self, account_name, account_key, container_name, prefix=None):
-        # NOTE: Azure wants all paths to start with a slash
-        prefix = "/{}".format(prefix.lstrip("/") if prefix else "")
+    def __init__(self, account_name, account_key, bucket_name, prefix=None):
+        prefix = "{}".format(prefix.lstrip("/") if prefix else "")
         super().__init__(prefix=prefix)
         self.account_name = account_name
         self.account_key = account_key
-        self.container_name = container_name
-        self.conn = BlobService(account_name=self.account_name, account_key=self.account_key)
+        self.container_name = bucket_name
+        self.conn = BlockBlobService(account_name=self.account_name, account_key=self.account_key)
         self.container = self.get_or_create_container(self.container_name)
-        self.log.debug("AzureTransfer initialized")
-        # XXX: AzureTransfer isn't actively tested and hasn't its error handling is probably lacking
-        self.log.warning("AzureTransfer is experimental and has not been thoroughly tested")
+        self.log.debug("AzureTransfer initialized, %r", self.container_name)
 
     def get_metadata_for_key(self, key):
-        key = self.format_key_for_backend(key)
-        return self._list_blobs(key)[0]["metadata"]
+        key = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=False)
+        results = self._list_blobs(key)
+        if not results:
+            raise FileNotFoundFromStorageError(key)
+        return results[0]["metadata"]
 
     def _metadata_for_key(self, key):
         return self._list_blobs(key)[0]["metadata"]
 
-    def list_path(self, key):
-        path = self.format_key_for_backend(key, trailing_slash=True)
+    def list_path(self, key, trailing_slash=True):  # pylint: disable=arguments-differ
+        # Trailing slash needed when listing directories, without when listing individual files
+        path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=trailing_slash)
         return self._list_blobs(path)
 
     def _list_blobs(self, path):
         self.log.debug("Listing path %r", path)
-        items = self.conn.list_blobs(self.container_name, prefix=path, delimiter="/", include="metadata")
-        result = []
+        if path:
+            items = self.conn.list_blobs(self.container_name, prefix=path, delimiter="/", include="metadata")
+        else:  # If you give Azure an empty path, it gives you an authentication error
+            items = self.conn.list_blobs(self.container_name, delimiter="/", include="metadata")
+        results = []
         for item in items:
-            result.append({
-                "last_modified": dateutil.parser.parse(item.properties.last_modified),
-                "metadata": item.metadata,
-                "name": self.format_key_from_backend(item.name),
-                "size": item.properties.content_length,
-            })
-        return result
+            if not isinstance(item, BlobPrefix):
+                results.append({
+                    "last_modified": item.properties.last_modified,
+                    # Azure Storage cannot handle '-' so we turn them into underscores and back again
+                    "metadata": dict((k.replace("_", "-"), v) for k, v in item.metadata.items()),
+                    "name": self.format_key_from_backend(item.name),
+                    "size": item.properties.content_length,
+                })
+        return results
 
     def delete_key(self, key):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", key)
-        return self.conn.delete_blob(self.container_name, key)
+        try:
+            return self.conn.delete_blob(self.container_name, key)
+        except azure.common.AzureMissingResourceHttpError as ex:
+            raise FileNotFoundFromStorageError(key) from ex
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
+
         self.log.debug("Starting to fetch the contents of: %r to: %r", key, filepath_to_store_to)
-        meta = self.conn.get_blob_to_path(self.container_name, key, filepath_to_store_to)
+        try:
+            self.conn.get_blob_to_path(self.container_name, key, filepath_to_store_to)
+        except azure.common.AzureMissingResourceHttpError as ex:
+            raise FileNotFoundFromStorageError(key) from ex
+
         if progress_callback:
             progress_callback(1, 1)
-        return meta
+        return self._metadata_for_key(key)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
+
         self.log.debug("Starting to fetch the contents of: %r", key)
-        meta = self.conn.get_blob_to_file(self.container_name, key, fileobj_to_store_to)
+        try:
+            self.conn.get_blob_to_stream(self.container_name, key, fileobj_to_store_to)
+        except azure.common.AzureMissingResourceHttpError as ex:
+            raise FileNotFoundFromStorageError(key) from ex
+
         if progress_callback:
             progress_callback(1, 1)
-        return meta
+
+        return self._metadata_for_key(key)
 
     def get_contents_to_string(self, key):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Starting to fetch the contents of: %r", key)
-        return self.conn.get_blob_to_bytes(self.container_name, key), self._metadata_for_key(key)
+        try:
+            blob = self.conn.get_blob_to_bytes(self.container_name, key)
+            return blob.content, blob.metadata
+        except azure.common.AzureMissingResourceHttpError as ex:
+            raise FileNotFoundFromStorageError(key) from ex
 
     def store_file_from_memory(self, key, memstring, metadata=None):
-        key = self.format_key_for_backend(key)
-        self.conn.put_block_blob_from_bytes(self.container_name, key, memstring,
-                                            x_ms_meta_name_values=self.sanitize_metadata(metadata))
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
+        self.conn.create_blob_from_bytes(self.container_name, key, memstring,
+                                         metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"))
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None):
-        key = self.format_key_for_backend(key)
-        self.conn.put_block_blob_from_path(self.container_name, key, filepath,
-                                           x_ms_meta_name_values=self.sanitize_metadata(metadata))
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
+        self.conn.create_blob_from_path(self.container_name, key, filepath,
+                                        metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"))
 
     def get_or_create_container(self, container_name):
-        start_time = time.time()
+        start_time = time.monotonic()
         self.conn.create_container(container_name)
-        self.log.debug("Got/Created container: %r successfully, took: %.3fs", container_name, time.time() - start_time)
+        self.log.debug("Got/Created container: %r successfully, took: %.3fs",
+                       container_name, time.monotonic() - start_time)
         return container_name

--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -17,7 +17,7 @@ class BaseTransfer:
             prefix += "/"
         self.prefix = prefix
 
-    def format_key_for_backend(self, key, trailing_slash=False):
+    def format_key_for_backend(self, key, remove_slash_prefix=False, trailing_slash=False):
         """Add a possible prefix to the key before sending it to the backend"""
         path = self.prefix + key
         if trailing_slash:
@@ -25,6 +25,8 @@ class BaseTransfer:
                 path += "/"
         else:
             path = path.rstrip("/")
+        if remove_slash_prefix:  # Azure defines slashes in the beginning as "dirs" for listing purposes
+            path = path.lstrip("/")
         return path
 
     def format_key_from_backend(self, key):
@@ -63,10 +65,10 @@ class BaseTransfer:
     def list_path(self, key):
         raise NotImplementedError
 
-    def sanitize_metadata(self, metadata):
+    def sanitize_metadata(self, metadata, replace_hyphen_with="-"):
         """Convert non-string metadata values to strings and drop null values"""
-        return {str(k): str(v) for k, v in (metadata or {}).items()
-                if v is not None}
+        return {str(k).replace("-", replace_hyphen_with): str(v)
+                for k, v in (metadata or {}).items() if v is not None}
 
     def store_file_from_memory(self, key, memstring, metadata=None):
         raise NotImplementedError

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -138,16 +138,16 @@ def _test_storage(st, driver, tmpdir):
         st.bucket.new_key = failing_new_key
 
         st.store_file_from_disk("test1/30m", test_file, multipart=True,
-                                metadata={"30m": "data", "size": test_size_send})
+                                metadata={"thirtymeg": "data", "size": test_size_send, "key": "value-with-a-hyphen"})
 
         assert fail_calls[0] > 3
     else:
         st.store_file_from_disk("test1/30m", test_file, multipart=True,
-                                metadata={"30m": "data", "size": test_size_send})
+                                metadata={"thirtymeg": "data", "size": test_size_send, "key": "value-with-a-hyphen"})
 
     os.unlink(test_file)
 
-    expected_meta = {"30m": "data", "size": str(test_size_send)}
+    expected_meta = {"thirtymeg": "data", "size": str(test_size_send), "key": "value-with-a-hyphen"}
     meta = st.get_metadata_for_key("test1/30m")
     assert meta == expected_meta
 


### PR DESCRIPTION
Azure-storage-python had in the meanwhile changed the names of
multiple methods and changed the behavior around listing of files.

Azure no longer accepts hyphen's '-', we replace them in metadata
now with an underscore '_' and then replace them back when doing
blob listings.

Also improve error handling so missing files are handled gracefully,
and add Azure to the list of tested storage backends. The storage
completes the tests successfully after this commit.