### PR TITLE
Change log level on some messages

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -222,8 +222,8 @@ class PGHoard:
         return xlog_path, basebackup_path
 
     def delete_remote_wal_before(self, wal_segment, site, pg_version):
-        self.log.debug("Starting WAL deletion from: %r before: %r, pg_version: %r",
-                       site, wal_segment, pg_version)
+        self.log.info("Starting WAL deletion from: %r before: %r, pg_version: %r",
+                      site, wal_segment, pg_version)
         storage = self.site_transfers.get(site)
         valid_timeline = True
         tli, log, seg = wal.name_to_tli_log_seg(wal_segment)


### PR DESCRIPTION
When setting log level on INFO, it's quite missleading to have only this message:
```
Could not delete wal_file: %r, returning
```

It looks like removal of old logwals failed.

I think it would be better to have this (even in INFO level):
```
Starting WAL deletion from: %r before: %r, pg_version: %r
Could not delete wal_file: %r, returning
```