### PR TITLE
pghoard: Fix Azure metadata fetching when fetching directly to memory

### DIFF
--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -96,7 +96,7 @@ class AzureTransfer(BaseTransfer):
         self.log.debug("Starting to fetch the contents of: %r", key)
         try:
             blob = self.conn.get_blob_to_bytes(self.container_name, key)
-            return blob.content, blob.metadata
+            return blob.content, self._metadata_for_key(key)
         except azure.common.AzureMissingResourceHttpError as ex:
             raise FileNotFoundFromStorageError(key) from ex
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -60,6 +60,9 @@ def _test_storage(st, driver, tmpdir):
     assert st.get_contents_to_fileobj("test1/x1", out) == {"k": "v"}
     assert out.getvalue() == b"dummy"
 
+    st.store_file_from_memory("test1/x1", b"l", {"fancymetadata": "value"})
+    assert st.get_contents_to_string("test1/x1") == (b"l", {"fancymetadata": "value"})
+
     st.store_file_from_memory("test1/x1", b"1", None)
     assert st.get_contents_to_string("test1/x1") == (b"1", {})
 


### PR DESCRIPTION
The blob.metadata object apparently is empty, we need to fetch the
actual metadata for the blob with a metadata listing call.

Also add a unit test to cover the case of fetching
metadata with get_contents_to_string.