### PR TITLE
pghoard: Get rid of .pgpass file use for security reasons

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -7,8 +7,8 @@ See LICENSE for details
 # pylint: disable=superfluous-parens
 from . import version, wal
 from .common import (
-    connection_string_using_pgpass,
-    replication_connection_string_and_slot_using_pgpass,
+    connection_string_for_node,
+    replication_connection_string_and_slot_for_node,
     set_stream_nonblocking,
     set_subprocess_stdout_and_stderr_nonblocking,
     terminate_subprocess,
@@ -129,7 +129,7 @@ class PGBaseBackup(Thread):
             if "host" in conn_info:
                 command.extend(["--host", conn_info["host"]])
         else:
-            connection_string, _ = replication_connection_string_and_slot_using_pgpass(self.connection_info)
+            connection_string, _ = replication_connection_string_and_slot_for_node(self.connection_info)
             command.extend([
                 "--progress",
                 "--dbname", connection_string
@@ -201,7 +201,7 @@ class PGBaseBackup(Thread):
         # an incorrect start-wal-time since the pg_basebackup from pghoard will not generate a new checkpoint.
         # This means that this xlog information would not be the oldest required to restore from this
         # basebackup.
-        connection_string, _ = replication_connection_string_and_slot_using_pgpass(self.connection_info)
+        connection_string, _ = replication_connection_string_and_slot_for_node(self.connection_info)
         start_wal_segment = wal.get_current_wal_from_identify_system(connection_string)
 
         temp_basebackup_dir, compressed_basebackup = self.get_paths_for_backup(self.basebackup_path)
@@ -428,7 +428,7 @@ class PGBaseBackup(Thread):
             rsa_public_key = self.config["backup_sites"][self.site]["encryption_keys"][encryption_key_id]["public"]
 
         self.log.debug("Connecting to database to start backup process")
-        connection_string = connection_string_using_pgpass(self.connection_info)
+        connection_string = connection_string_for_node(self.connection_info)
         with psycopg2.connect(connection_string) as db_conn:
             cursor = db_conn.cursor()
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -11,7 +11,7 @@ from pghoard.basebackup import PGBaseBackup
 from pghoard.common import (
     create_alert_file,
     get_object_storage_config,
-    replication_connection_string_and_slot_using_pgpass,
+    replication_connection_string_and_slot_for_node,
     write_json_file,
 )
 from pghoard.compressor import CompressorThread
@@ -123,7 +123,7 @@ class PGHoard:
         return True
 
     def create_basebackup(self, site, connection_info, basebackup_path, callback_queue=None):
-        connection_string, _ = replication_connection_string_and_slot_using_pgpass(connection_info)
+        connection_string, _ = replication_connection_string_and_slot_for_node(connection_info)
         pg_version_server = self.check_pg_server_version(connection_string)
         if pg_version_server:
             self.config["backup_sites"][site]["pg_version"] = pg_version_server
@@ -163,7 +163,7 @@ class PGHoard:
         return pg_version
 
     def receivexlog_listener(self, site, connection_info, xlog_directory):
-        connection_string, slot = replication_connection_string_and_slot_using_pgpass(connection_info)
+        connection_string, slot = replication_connection_string_and_slot_for_node(connection_info)
         pg_version_server = self.check_pg_server_version(connection_string)
         if pg_version_server:
             self.config["backup_sites"][site]["pg_version"] = pg_version_server
@@ -182,7 +182,7 @@ class PGHoard:
         self.receivexlogs[site] = thread
 
     def start_walreceiver(self, site, chosen_backup_node, last_flushed_lsn):
-        connection_string, slot = replication_connection_string_and_slot_using_pgpass(chosen_backup_node)
+        connection_string, slot = replication_connection_string_and_slot_for_node(chosen_backup_node)
         pg_version_server = self.check_pg_server_version(connection_string)
         if pg_version_server:
             self.config["backup_sites"][site]["pg_version"] = pg_version_server

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -4,7 +4,7 @@ pghoard: inspect WAL files
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
-from .common import replication_connection_string_and_slot_using_pgpass
+from .common import replication_connection_string_and_slot_for_node
 from collections import namedtuple
 import re
 import struct
@@ -118,7 +118,7 @@ def get_current_wal_from_identify_system(conn_str):
 
 
 def get_current_wal_file(node_info):
-    conn_str, _ = replication_connection_string_and_slot_using_pgpass(node_info)
+    conn_str, _ = replication_connection_string_and_slot_for_node(node_info)
     return get_current_wal_from_identify_system(conn_str)
 
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -6,7 +6,6 @@ See LICENSE for details
 """
 from .base import PGHoardTestCase
 from pghoard.common import (
-    create_pgpass_file,
     convert_pg_command_version_to_number,
     default_json_serialization,
     json_encode,
@@ -15,39 +14,10 @@ from pghoard.common import (
 from pghoard.rohmu.errors import Error
 import datetime
 import json
-import os
 import pytest
 
 
 class TestCommon(PGHoardTestCase):
-    def test_create_pgpass_file(self):
-        original_home = os.environ['HOME']
-
-        def get_pgpass_contents():
-            with open(os.path.join(self.temp_dir, ".pgpass"), "rb") as fp:
-                return fp.read()
-        os.environ['HOME'] = self.temp_dir
-        # make sure our pgpass entry ends up in the file and the call returns a connection string without password
-        pwl = create_pgpass_file("host=localhost port='5432' user=foo password='bar' dbname=replication")
-        assert pwl == "dbname='replication' host='localhost' port='5432' user='foo'"
-        assert get_pgpass_contents() == b'localhost:5432:replication:foo:bar\n'
-        # See that it does not add a new row when repeated
-        pwl = create_pgpass_file("host=localhost port='5432' user=foo password='bar' dbname=replication")
-        assert pwl == "dbname='replication' host='localhost' port='5432' user='foo'"
-        assert get_pgpass_contents() == b'localhost:5432:replication:foo:bar\n'
-        # See that it does not add a new row when repeated as url
-        pwl = create_pgpass_file("postgres://foo:bar@localhost/replication")
-        # NOTE: create_pgpass_file() always returns the string in libpq format
-        assert pwl == "dbname='replication' host='localhost' user='foo'"
-        assert get_pgpass_contents() == b'localhost:5432:replication:foo:bar\n'
-        # See that it add a new row for a different user
-        create_pgpass_file("postgres://another:bar@localhost/replication")
-        assert get_pgpass_contents() == b'localhost:5432:replication:foo:bar\nlocalhost:5432:replication:another:bar\n'
-        # See that it replaces the previous row when we change password
-        pwl = create_pgpass_file("postgres://foo:xyz@localhost/replication")
-        assert get_pgpass_contents() == b'localhost:5432:replication:another:bar\nlocalhost:5432:replication:foo:xyz\n'
-        os.environ['HOME'] = original_home
-
     def test_pg_versions(self):
         assert convert_pg_command_version_to_number("foobar (PostgreSQL) 9.4.1") == 90401
         assert convert_pg_command_version_to_number("asdf (PostgreSQL) 9.5alpha1") == 90500


### PR DESCRIPTION
While .pgpass use has been convenient it has had the unfortunate
side issue of having yet-another-place where to store the user credentials.

Since we don't absolutely need it, lets get rid of it.