### PR TITLE
local-tar basebackup: abort a conflicting exclusive backup if one is running

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,10 @@ pghoard X.X.X (2016-XX-XX)
   versions require the pgespresso extension to take backups of replicas
   using the `local-tar` method, the pg_basebackup utilizing (default)
   methods have always supported backups of replicas.
+* When `local-tar` basebackups are used in exclusive mode (PG <= 9.5 without
+  pgespresso) any conflicting exclusive basebackup is automatically cancelled
+  to allow PGHoard to take its own basebackup.  This is sometimes required if
+  a previous PGHoard process has been killed while it was taking a backup.
 * Miscellaneous bug fixes
 
 pghoard 1.4.0 (2016-07-22)

--- a/pghoard/rohmu/inotify.py
+++ b/pghoard/rohmu/inotify.py
@@ -23,6 +23,7 @@ class InotifyEvent(ctypes.Structure):
         ("name", c_char_p),
     ]
 
+
 s_size = 16
 # default 2048 events
 INOTIFY_EVENT_BUFFER_SIZE = 2048 * (ctypes.sizeof(InotifyEvent) + s_size)

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -215,7 +215,7 @@ LABEL: pg_basebackup base backup
             with psycopg2.connect(conn_str) as conn:
                 conn.autocommit = True
                 cursor = conn.cursor()
-                cursor.execute("SELECT pg_start_backup('conflicting')")
+                cursor.execute("SELECT pg_start_backup('conflicting')")  # pylint: disable=used-before-assignment
                 need_stop = True
             self._test_basebackups(capsys, db, pghoard, tmpdir, "local-tar")
             need_stop = False


### PR DESCRIPTION


When `local-tar` basebackups are used in exclusive mode (PG <= 9.5 without
pgespresso) any conflicting exclusive basebackup is automatically cancelled
to allow PGHoard to take its own basebackup.  This is sometimes required if
a previous PGHoard process has been killed while it was taking a backup.