### PR TITLE
basebackups: store backup end time and segment in metadata in local-tar mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 pghoard X.X.X (2016-XX-XX)
 ==========================
 
+* Basebackup `end-time` and `end-wal-segment` are now stored in metadata and
+  used for PITR when `local-tar` basebackups are used.
 * Azure object storage updated to work with the latest python-azure-storage
   module and promoted to production ready status
 * Google object storage driver now retries operations on failure to work

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -159,6 +159,11 @@ LABEL: pg_basebackup base backup
         assert pghoard.test_site in out
         assert "pg-version" in out
 
+        assert "start-wal-segment" in out
+        if mode == "local-tar":
+            assert "end-time" in out
+            assert "end-wal-segment" in out
+
     def _test_restore_basebackup(self, db, pghoard, tmpdir):
         backup_out = tmpdir.join("test-restore").strpath
         # Restoring to empty directory works


### PR DESCRIPTION


Basebackup `end-time` and `end-wal-segment` are now stored in metadata and
used for PITR when `local-tar` basebackups are used.

When performing recovery to a given point the point must be after the end of
the backup, so try to store such a time in the metadata.  The pg_basebackup
methods don't currently store it as there's no way to get it over a
replication protocol.  We'll probably require a non-replication connection
to the db in the future for all basebackup types.