### PR TITLE
pghoard: Set compression/transfer thread defaults based on cpu count

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ pghoard X.X.X (2016-XX-XX)
   to allow PGHoard to take its own basebackup.  This is sometimes required if
   a previous PGHoard process has been killed while it was taking a backup.
 * Support pghoard_restore --recovery-target-action with 9.3 and 9.4
+* Autotune compression.thread_count and transfer_agent.thread_count defaults
+  to be max(cpu_count, 5) instead of a default of 5 as before.
 * Miscellaneous bug fixes
 
 pghoard 1.4.0 (2016-07-22)

--- a/README.rst
+++ b/README.rst
@@ -618,11 +618,11 @@ Determines syslog log facility. (requires syslog to be true as well)
 
  * ``algorithm`` default ``"snappy"`` if available, otherwise ``"lzma"``
  * ``level`` default ``"0"`` compression level for ``"lzma"`` compression
- * ``thread_count`` (default ``5``) number of parallel compression threads
+ * ``thread_count`` (default max(cpu_count, ``5``)) number of parallel compression threads
 
 * ``transfer`` WAL/basebackup transfer parameters
 
- * ``thread_count`` (default ``5``) number of parallel uploads/downloads
+ * ``thread_count`` (default max(cpu_count, ``5``)) number of parallel uploads/downloads
 
 
 Alert files

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -10,11 +10,16 @@ from pghoard.rohmu import get_class_for_transfer
 from pghoard.rohmu.errors import InvalidConfigurationError
 from pghoard.rohmu.snappyfile import snappy
 import json
+import multiprocessing
 import os
 import subprocess
 
 
 SUPPORTED_VERSIONS = ["9.6", "9.5", "9.4", "9.3", "9.2"]
+
+
+def get_cpu_count():
+    return multiprocessing.cpu_count()
 
 
 def find_pg_binary(program, versions=None):
@@ -40,8 +45,8 @@ def set_config_defaults(config, *, check_commands=True):
     config.setdefault("upload_retries_warning_limit", 3)
 
     # default to 5 compression and transfer threads
-    config.setdefault("compression", {}).setdefault("thread_count", 5)
-    config.setdefault("transfer", {}).setdefault("thread_count", 5)
+    config.setdefault("compression", {}).setdefault("thread_count", max(get_cpu_count(), 5))
+    config.setdefault("transfer", {}).setdefault("thread_count", max(get_cpu_count(), 5))
     # default to prefetching min(#compressors, #transferagents) - 1 objects so all
     # operations where prefetching is used run fully in parallel without waiting to start
     config.setdefault("restore_prefetch", min(

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -13,6 +13,7 @@ from pghoard.rohmu import compat
 from unittest.mock import Mock, patch
 import datetime
 import json
+import multiprocessing
 import os
 
 
@@ -202,7 +203,7 @@ dbname|"""
     def test_backup_state_file(self):
         self.pghoard.write_backup_state_to_json_file()
         state_path = self.config["json_state_file_path"]
-        thread_count = 5
+        thread_count = max(multiprocessing.cpu_count(), 5)
         with open(state_path, "r") as fp:
             state = json.load(fp)
         empty_state = {


### PR DESCRIPTION
In case of a machine with many CPUs try to set a better default than
5 as the threadcount. Now it's set to max(cpu_count, 5).