### PR TITLE
webserver: don't refetch xlog files if we happen to have them already

### DIFF
--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -345,6 +345,23 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._save_and_verify_restored_file(filetype, filename, prefetch_target_path, target_path)
             raise HttpResponse(status=201)
 
+        # After reaching a recovery_target and restart of a PG server, PG wants to replay and refetch
+        # files from the archive starting from the latest checkpoint. We have potentially fetched these files
+        # already earlier. Check if we have the files already and if we do, don't go over the network to refetch
+        # them yet again but just rename them to the path that PG is requesting.
+        xlog_path = os.path.join(xlog_dir, filename)
+        if os.path.exists(xlog_path):
+            self.server.log.debug("Requested %r, found it in pg_xlog directory as: %r, returning directly",
+                                  filename, xlog_path)
+            success = False
+            try:
+                self._save_and_verify_restored_file(filetype, filename, xlog_path, target_path)
+                success = True
+            except ValueError as ex:
+                self.server.log.warning("Found file: %r but it was invalid: %s", xlog_path, ex)
+            if success:
+                raise HttpResponse(status=201)
+
         prefetch_n = self.server.config["restore_prefetch"]
         prefetch = []
         if filetype == "timeline":

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -455,7 +455,7 @@ class TestWebServer:
         assert content == restored_data
 
     def test_get_encrypted_archived_file(self, pghoard):
-        xlog_seg = "000000010000000000000010"
+        xlog_seg = "000000420000000000000010"
         content = wal_header_for_file(xlog_seg)
         compressor = pghoard.Compressor()
         compressed_content = compressor.compress(content) + (compressor.flush() or b"")


### PR DESCRIPTION
Previously during recovery if we reached a recovery target and restarted
PostgreSQL, pghoard would refetch all xlog files since the last checkpoint
again. Now we check if we already have them and just use them as-is.