### PR TITLE
pghoard: When restoring try to fetch a file from the archive if local…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 
 python:
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - "pip install boto cryptography flake8 httplib2 mock psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests azure azure-storage"

--- a/pghoard/patchedtarfile.py
+++ b/pghoard/patchedtarfile.py
@@ -5,6 +5,7 @@
 
 from pghoard.rohmu import IO_BLOCK_SIZE as BUFSIZE
 import shutil
+import sys
 import tarfile
 
 
@@ -35,4 +36,5 @@ def copyfileobj(src, dst, length=None, exception=OSError):
     return
 
 
-tarfile.copyfileobj = copyfileobj
+if sys.version_info < (3, 6, 0):
+    tarfile.copyfileobj = copyfileobj


### PR DESCRIPTION
… invalid

We now catch HttpResponse errors as well and properly try fetching the data
from the object storage. Add a unit test for this case as well.