### PR TITLE
dates: start using a tz-aware helper function for parsing timestamps

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -14,12 +14,11 @@ from .common import (
     terminate_subprocess,
 )
 from .patchedtarfile import tarfile
-from pghoard.rohmu import errors, rohmufile
+from pghoard.rohmu import dates, errors, rohmufile
 from pghoard.rohmu.compat import suppress
 from tempfile import NamedTemporaryFile
 from threading import Thread
 import datetime
-import dateutil.parser
 import io
 import json
 import logging
@@ -248,7 +247,8 @@ class PGBaseBackup(Thread):
                 start_wal_segment = line.split()[5].strip(b")").decode("utf8")
             elif line.startswith(b"START TIME: "):
                 start_time_text = line[len("START TIME: "):].decode("utf8")
-                start_time = dateutil.parser.parse(start_time_text).isoformat()  # pylint: disable=no-member
+                start_time_dt = dates.parse_timestamp(start_time_text, assume_local=True)
+                start_time = start_time_dt.isoformat()
         self.log.debug("Found: %r as starting wal segment, start_time: %r",
                        start_wal_segment, start_time)
         return start_wal_segment, start_time

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -18,14 +18,13 @@ from pghoard.compressor import CompressorThread
 from pghoard.rohmu.inotify import InotifyWatcher
 from pghoard.transfer import TransferAgent
 from pghoard.receivexlog import PGReceiveXLog
-from pghoard.rohmu import get_transfer
+from pghoard.rohmu import dates, get_transfer
 from pghoard.rohmu.compat import suppress
 from pghoard.rohmu.errors import FileNotFoundFromStorageError, InvalidConfigurationError
 from pghoard.webserver import WebServer
 from queue import Empty, Queue
 import argparse
 import datetime
-import dateutil.parser
 import json
 import logging
 import os
@@ -277,7 +276,7 @@ class PGHoard:
         for entry in results:
             # drop path from resulting list and convert timestamps
             entry["name"] = os.path.basename(entry["name"])
-            entry["metadata"]["start-time"] = dateutil.parser.parse(entry["metadata"]["start-time"])
+            entry["metadata"]["start-time"] = dates.parse_timestamp(entry["metadata"]["start-time"])
 
         results.sort(key=lambda entry: entry["metadata"]["start-time"])
         return results

--- a/pghoard/rohmu/dates.py
+++ b/pghoard/rohmu/dates.py
@@ -1,0 +1,40 @@
+"""
+rohmu - timestamp handling
+
+Copyright (c) 2017 Ohmu Ltd
+See LICENSE for details
+"""
+import datetime
+import dateutil.parser
+import dateutil.tz
+
+
+def parse_timestamp(ts, *, with_tz=True, assume_local=False):
+    """Parse a given timestamp and return a datetime object with or without tzinfo.
+
+    If `with_tz` is False and we can't parse a timezone from the timestamp the datetime object is returned
+    as-is and we assume the timezone is whatever was requested.  If `with_tz` is False and we can parse a
+    timezone, the timestamp is converted to either local or UTC time based on `assume_local` after which tzinfo
+    is stripped and the timestamp is returned.
+
+    When `with_tz` is True and there's a timezone in the timestamp we return it as-is.  If `with_tz` is True
+    but we can't parse a timezone we add either local or UTC timezone to the datetime based on `assume_local`.
+    """
+    parse_result = dateutil.parser.parse(ts)
+
+    # pylint thinks dateutil.parser.parse always returns a tuple even though we didn't request it.
+    # So this check is pointless but convinces pylint that we really have a datetime object now.
+    dt = parse_result[0] if isinstance(parse_result, tuple) else parse_result  # pylint: disable=unsubscriptable-object
+
+    if with_tz is False:
+        if not dt.tzinfo:
+            return dt
+
+        tz = dateutil.tz.tzlocal() if assume_local else datetime.timezone.utc
+        return dt.astimezone(tz).replace(tzinfo=None)
+
+    if dt.tzinfo:
+        return dt
+
+    tz = dateutil.tz.tzlocal() if assume_local else datetime.timezone.utc
+    return dt.replace(tzinfo=tz)

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -12,7 +12,6 @@ import googleapiclient  # noqa pylint: disable=unused-import
 
 from contextlib import contextmanager
 from io import BytesIO, FileIO
-import dateutil.parser
 import errno
 import httplib2
 import json
@@ -44,6 +43,7 @@ except ImportError:
             scopes=[])
 
 
+from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError
 from .base import BaseTransfer
 
@@ -179,7 +179,7 @@ class GoogleTransfer(BaseTransfer):
                 return_list.append({
                     "name": self.format_key_from_backend(item["name"]),
                     "size": int(item["size"]),
-                    "last_modified": dateutil.parser.parse(item["updated"]),
+                    "last_modified": parse_timestamp(item["updated"]),
                     "metadata": item.get("metadata", {}),
                 })
         return return_list

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -6,12 +6,12 @@ See LICENSE for details
 """
 import boto.exception
 import boto.s3
-import dateutil.parser
 import math
 import os
 import time
 from boto.s3.connection import OrdinaryCallingFormat
 from boto.s3.key import Key
+from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 from .base import BaseTransfer
 
@@ -87,7 +87,7 @@ class S3Transfer(BaseTransfer):
             if name == path:
                 continue  # skip the path itself
             result.append({
-                "last_modified": dateutil.parser.parse(item.last_modified),
+                "last_modified": parse_timestamp(item.last_modified),
                 "metadata": self._metadata_for_key(item.name),
                 "name": name,
                 "size": item.size,

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -6,10 +6,9 @@ See LICENSE for details
 """
 from .base import BaseTransfer
 from ..compat import suppress
+from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError
 from swiftclient import client, exceptions  # pylint: disable=import-error
-import datetime
-import dateutil.parser
 import logging
 import os
 import time
@@ -104,9 +103,7 @@ class SwiftTransfer(BaseTransfer):
                 continue  # skip directory entries
             metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
             segments_size = metadata.pop("_segments_size", 0)
-            last_modified = dateutil.parser.parse(item["last_modified"])
-            if last_modified.tzinfo is None:  # Assume UTC  # pylint: disable=no-member
-                last_modified = last_modified.replace(tzinfo=datetime.timezone.utc)  # pylint: disable=no-member
+            last_modified = parse_timestamp(item["last_modified"])
             return_list.append({
                 "name": self.format_key_from_backend(item["name"]),
                 "size": item["bytes"] + segments_size,

--- a/test/test_rohmu_dates.py
+++ b/test/test_rohmu_dates.py
@@ -1,0 +1,30 @@
+"""
+rohmu test case
+
+Copyright (c) 2017 Ohmu Ltd
+See LICENSE for details
+"""
+from pghoard.rohmu.dates import parse_timestamp
+import datetime
+import dateutil.tz
+
+
+def test_parse_timestamp():
+    local_aware = datetime.datetime.now(dateutil.tz.tzlocal())
+
+    str_local_aware_naive = local_aware.isoformat().split("+", 1)[0]
+    str_local_aware_named = "{} {}".format(str_local_aware_naive, local_aware.tzname())
+
+    assert parse_timestamp(str_local_aware_named) == local_aware
+    local_naive = parse_timestamp(str_local_aware_named, with_tz=False, assume_local=True)
+    assert local_naive == local_aware.replace(tzinfo=None)
+
+    str_unknown_aware = "2017-02-02 12:00:00 XYZ"
+    unknown_aware_utc = parse_timestamp(str_unknown_aware)
+    assert unknown_aware_utc.tzinfo == datetime.timezone.utc
+    assert unknown_aware_utc.isoformat() == "2017-02-02T12:00:00+00:00"
+
+    if local_aware.tzname() in ["EET", "EEST"]:
+        unknown_aware_local = parse_timestamp(str_unknown_aware, assume_local=True)
+        assert unknown_aware_local.tzinfo == dateutil.tz.tzlocal()
+        assert unknown_aware_local.isoformat() == "2017-02-02T12:00:00+02:00"


### PR DESCRIPTION
Previously we just used `dateutil.parser.parse` to handle timestamps, but
that's not really good enough as we can't be sure whether or not we get a
valid timezone back, and when we're comparing `datetime` objects they must
all be either tz-aware or tz-naive.

This commit implements a new helper function that parses timestamps using
`dateutil.parser.parse` and then either makes sure that the resulting object
*does* or *does not* include a `tzinfo`.

This fixes a bug where the timestamp parsed from a basebackup's
`backup_label` wasn't recognized and we ended up with a naive `datetime`
which later on would cause errors when it was being compared to other
tz-aware `datetime` objects.