### PR TITLE
pghoard: retry on google api BrokenPipeError

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -456,7 +456,7 @@ class PGHoard:
                     self.handle_site(site, site_config)
                 self.write_backup_state_to_json_file()
             except subprocess.CalledProcessError as ex:
-                self.log.error("%s: %s", ex.__class__.__name__, ex)
+                self.log.error("main loop: %s: %s, retrying...", ex.__class__.__name__, ex)
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.exception("Unexpected exception in PGHoard main loop")
                 self.stats.unexpected_exception(ex, where="pghoard_run")

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -128,7 +128,7 @@ class GoogleTransfer(BaseTransfer):
                 # and the order of handling the errors here needs to be correct
                 if not retries:
                     raise
-                elif isinstance(ex, (socket.timeout, ssl.SSLEOFError)):
+                elif isinstance(ex, (socket.timeout, ssl.SSLEOFError, BrokenPipeError)):
                     pass  # just retry with the same sleep amount
                 elif isinstance(ex, HttpError):
                     # https://cloud.google.com/storage/docs/json_api/v1/status-codes


### PR DESCRIPTION
Google Cloud library sometimes fails with a BrokenPipeError and the
next request is successful.