### PR TITLE
fix s3 multipart upload to account for more than 1000 parts

### DIFF
--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -177,7 +177,7 @@ class S3Transfer(BaseTransfer):
                     self.log.info("Upload of part: %r/%r of %r, part size: %r took: %.2fs",
                                   part_num, chunks, filepath, self.multipart_chunk_size,
                                   time.monotonic() - start_time)
-            if len(mp.get_all_parts()) == chunks:
+            if len(list(mp)) == chunks:
                 self.log.info("Multipart upload of %r, size: %r, took: %.2fs, now completing multipart",
                               filepath, size, time.monotonic() - start_of_multipart_upload)
                 mp.complete_upload()


### PR DESCRIPTION
S3 multipart file uploads that have more than 1000 chunks fail due to `boto`
paginating the results of `multipart_upload.get_all_parts()` to 1000.  The
`boto` docs recommend using the `MultiPartUpload` object as an iterator instead
so that pagination happens automatically.

http://boto.cloudhackers.com/en/latest/ref/s3.html#module-boto.s3.multipart