### PR TITLE
prevent backups when maintenance mode file exists

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -40,6 +40,7 @@ def set_config_defaults(config, *, check_commands=True):
     config.setdefault("http_port", PGHOARD_PORT)
     config.setdefault("alert_file_dir", config.get("backup_location") or os.getcwd())
     config.setdefault("json_state_file_path", "/tmp/pghoard_state.json")  # XXX: get a better default
+    config.setdefault("maintenance_mode_file", "/tmp/pghoard_maintenance_mode_file")
     config.setdefault("log_level", "INFO")
     config.setdefault("path_prefix", "")
     config.setdefault("upload_retries_warning_limit", 3)

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -442,7 +442,7 @@ class PGHoard:
                               site, delta_since_last_backup)
                 new_backup_needed = True
 
-        if new_backup_needed:
+        if new_backup_needed and not os.path.exists(self.config["maintenance_mode_file"]):
             self.basebackups_callbacks[site] = Queue()
             self.create_basebackup(site, chosen_backup_node, basebackup_path, self.basebackups_callbacks[site])
 


### PR DESCRIPTION
The README mentions a maintenance mode file.  This PR adds a default config value and checks for the file when determining if a new base backup is needed.