### PR TITLE
tests: Fix webserver unittest failure by using a different WAL segment

### DIFF
--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -494,7 +494,7 @@ class TestWebServer:
         assert content == restored_data
 
     def test_get_encrypted_archived_file(self, pghoard):
-        xlog_seg = "000000010000000000000010"
+        xlog_seg = "000000090000000000000010"
         content = wal_header_for_file(xlog_seg)
         compressor = pghoard.Compressor()
         compressed_content = compressor.compress(content) + (compressor.flush() or b"")


### PR DESCRIPTION
The test_handle_site in test_basebackup created the same WAL file
and if it was run before test_get_encrypted_archived_file the test
would fail since it would return the pre-existing data.

The reason the data passes the webserver code's prefetch correctness
checks is that it really had the correct WAL file header.