### PR TITLE
Allow for usage of IAM roles

### DIFF
--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -30,10 +30,10 @@ def _location_for_region(region):
 
 class S3Transfer(BaseTransfer):
     def __init__(self,
-                 aws_access_key_id,
-                 aws_secret_access_key,
                  region,
                  bucket_name,
+                 aws_access_key_id=None,
+                 aws_secret_access_key=None,
                  prefix=None,
                  host=None,
                  port=None,


### PR DESCRIPTION
Allows for using s3 object storage with IAM role authentication.

Currently my docker image is running below code in an additional layer as all our authentication is done using IAM roles.
```
RUN sed -i -r 's/ +aws_access_key_id,//' /usr/lib/python3.6/site-packages/pghoard/rohmu/object_storage/s3.py \
 && sed -i -r 's/ +aws_secret_access_key,//' /usr/lib/python3.6/site-packages/pghoard/rohmu/object_storage/s3.py \
 && sed -i -r 's/encrypted=False\):/encrypted=False,aws_access_key_id=None,aws_secret_access_key=None):/' /usr/lib/python3.6/site-packages/pghoard/rohmu/object_storage/s3.py
```

Closes #213 