### PR TITLE
config: adjust default thread counts for transfer and compression

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -45,14 +45,18 @@ def set_config_defaults(config, *, check_commands=True):
     config.setdefault("path_prefix", "")
     config.setdefault("upload_retries_warning_limit", 3)
 
-    # default to 5 compression and transfer threads
-    config.setdefault("compression", {}).setdefault("thread_count", max(get_cpu_count(), 5))
-    config.setdefault("transfer", {}).setdefault("thread_count", max(get_cpu_count(), 5))
-    # default to prefetching min(#compressors, #transferagents) - 1 objects so all
-    # operations where prefetching is used run fully in parallel without waiting to start
-    config.setdefault("restore_prefetch", min(
-        config["compression"]["thread_count"],
-        config["transfer"]["thread_count"]) - 1)
+    # default to cpu_count + 1 compression threads
+    config.setdefault("compression", {}).setdefault(
+        "thread_count",
+        get_cpu_count() + 1,
+    )
+    # default to cpu_count + 3 transfer threads (max 20)
+    config.setdefault("transfer", {}).setdefault(
+        "thread_count",
+        min(get_cpu_count() + 3, 20),
+    )
+    # default to prefetching transfer.thread_count objects
+    config.setdefault("restore_prefetch", config["transfer"]["thread_count"])
     # if compression algorithm is not explicitly set prefer snappy if it's available
     if snappy is not None:
         config["compression"].setdefault("algorithm", "snappy")

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -155,7 +155,7 @@ class CompressionCase(PGHoardTestCase):
             "src_path": file_path_partial,
             "full_path": file_path,
         })
-        transfer_event = self.transfer_queue.get(timeout=1.0)
+        transfer_event = self.transfer_queue.get(timeout=5.0)
         expected = {
             "filetype": filetype,
             "local_path": file_path.replace(self.incoming_path, self.handled_path),
@@ -223,7 +223,7 @@ class CompressionCase(PGHoardTestCase):
             },
             "site": self.test_site,
         }
-        transfer_event = self.transfer_queue.get(timeout=1.0)
+        transfer_event = self.transfer_queue.get(timeout=5.0)
         for key, value in expected.items():
             assert transfer_event[key] == value
 
@@ -239,7 +239,7 @@ class CompressionCase(PGHoardTestCase):
             "type": "CLOSE_WRITE",
         }
         transfer_event = self.compression_queue.put(event)
-        transfer_event = self.transfer_queue.get(timeout=1.0)
+        transfer_event = self.transfer_queue.get(timeout=5.0)
         expected = {
             "callback_queue": callback_queue,
             "filetype": "xlog",
@@ -275,7 +275,7 @@ class CompressionCase(PGHoardTestCase):
             "site": self.test_site,
             "type": "DECOMPRESSION",
         })
-        callback_queue.get(timeout=1.0)
+        callback_queue.get(timeout=5.0)
         assert os.path.exists(local_filepath) is True
         with open(local_filepath, "rb") as fp:
             fdata = fp.read()
@@ -311,7 +311,7 @@ class CompressionCase(PGHoardTestCase):
             "site": self.test_site,
             "type": "DECOMPRESSION",
         })
-        callback_queue.get(timeout=1.0)
+        callback_queue.get(timeout=5.0)
         assert os.path.exists(local_filepath) is True
         with open(local_filepath, "rb") as fp:
             fdata = fp.read()

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -13,7 +13,6 @@ from pghoard.rohmu import compat
 from unittest.mock import Mock, patch
 import datetime
 import json
-import multiprocessing
 import os
 
 
@@ -203,18 +202,17 @@ dbname|"""
     def test_backup_state_file(self):
         self.pghoard.write_backup_state_to_json_file()
         state_path = self.config["json_state_file_path"]
-        thread_count = max(multiprocessing.cpu_count(), 5)
         with open(state_path, "r") as fp:
             state = json.load(fp)
         empty_state = {
             "startup_time": self.pghoard.state["startup_time"],
             "backup_sites": {},
-            "compressors": [{}] * thread_count,
+            "compressors": [{}] * self.config["compression"]["thread_count"],
             "queues": {
                 "compression_queue": 0,
                 "transfer_queue": 0,
             },
-            "transfer_agents": [{}] * thread_count,
+            "transfer_agents": [{}] * self.config["transfer"]["thread_count"],
             "pg_receivexlogs": {},
             "pg_basebackups": {},
             "walreceivers": {},


### PR DESCRIPTION
Try to run more transfer agents in parallel with low cpu counts to better
utilize network resources and to work around issues where one transfer
stalls for a while.