### PR TITLE
config: don't require pgdata to have a version if we're running pghoard_restore

### DIFF
--- a/pghoard/archive_cleanup.py
+++ b/pghoard/archive_cleanup.py
@@ -22,7 +22,7 @@ class ArchiveCleanup:
         self.storage = None
 
     def set_config(self, config_file, site):
-        self.config = config.read_json_config_file(config_file, check_commands=False)
+        self.config = config.read_json_config_file(config_file, check_commands=False, check_pgdata=False)
         self.site = config.get_site_from_config(self.config, site)
         self.backup_site = self.config["backup_sites"][self.site]
         storage_config = common.get_object_storage_config(self.config, self.site)

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -184,7 +184,7 @@ class Restore:
 
     def list_basebackups(self, arg):
         """List basebackups from an object store"""
-        self.config = config.read_json_config_file(arg.config, check_commands=False)
+        self.config = config.read_json_config_file(arg.config, check_commands=False, check_pgdata=False)
         site = config.get_site_from_config(self.config, arg.site)
         self.storage = self._get_object_storage(site, pgdata=None)
         self.storage.show_basebackup_list(verbose=arg.verbose)
@@ -199,7 +199,7 @@ class Restore:
             except ValueError:
                 raise RestoreError("Invalid tablespace mapping {!r}".format(arg.tablespace_dir))
 
-        self.config = config.read_json_config_file(arg.config, check_commands=False)
+        self.config = config.read_json_config_file(arg.config, check_commands=False, check_pgdata=False)
         site = config.get_site_from_config(self.config, arg.site)
         try:
             self.storage = self._get_object_storage(site, arg.target_dir)

--- a/test/base.py
+++ b/test/base.py
@@ -1,11 +1,11 @@
 """
-pghoard
+pghoard - unit test setup
 
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 # pylint: disable=attribute-defined-outside-init
-from pghoard.config import find_pg_binary, set_config_defaults
+from pghoard.config import find_pg_binary, set_and_check_config_defaults
 from shutil import rmtree
 from tempfile import mkdtemp
 import logging
@@ -80,7 +80,7 @@ class PGHoardTestCase:
         }
         if ver == "10":
             config["backup_sites"][self.test_site]["pg_receivexlog_path"] = os.path.join(bindir, "pg_receivewal")
-        return set_config_defaults(config)
+        return set_and_check_config_defaults(config)
 
     def setup_method(self, method):
         self.temp_dir = mkdtemp(prefix=self.__class__.__name__)


### PR DESCRIPTION


We're just trying to retrieve a basebackup there's no point in trying to
read a version file from the empty directory.  Also, archive_cleanup doesn't
really need it either so disable the check there, too.