### PR TITLE
tests: rename TestPG and TestWAL so not to confuse pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ build-dep-fed:
 		python3-boto python3-cryptography python3-dateutil python3-devel \
 		python3-flake8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests python3-snappy \
+		python3-azure-storage \
 		rpm-build
 
 test: flake8 pylint unittest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,7 +26,7 @@ import time
 logutil.configure_logging()
 
 
-class TestPG:
+class PGTester:
     def __init__(self, pgdata):
         pgver = os.getenv("PG_VERSION")
         pgbin, ver = pghconfig.find_pg_binary("", versions=[pgver] if pgver else None)
@@ -79,7 +79,7 @@ def setup_pg():
     tmpdir = str(tmpdir_obj)
     # try to find the binaries for these versions in some path
     pgdata = os.path.join(tmpdir, "pgdata")
-    db = TestPG(pgdata)  # pylint: disable=redefined-outer-name
+    db = PGTester(pgdata)  # pylint: disable=redefined-outer-name
     db.run_cmd("initdb", "-D", pgdata, "--encoding", "utf-8")
     # NOTE: does not use TCP ports, no port conflicts
     db.user = dict(host=pgdata, user="pghoard", password="pghoard", dbname="postgres", port="5432")

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -4,7 +4,7 @@ pghoard - basebackup tests
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
-from .conftest import TestPG
+from .conftest import PGTester
 from copy import deepcopy
 from pghoard import common, pgutil, statsd
 from pghoard.basebackup import PGBaseBackup
@@ -385,7 +385,7 @@ LABEL: pg_basebackup base backup
                 fp.seek(0)
                 fp.write(rconf)
 
-            r_db = TestPG(backup_out)
+            r_db = PGTester(backup_out)
             r_db.user = dict(db.user, host=backup_out)
             r_db.run_pg()
             r_conn_str = pgutil.create_connection_string(r_db.user)

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -19,7 +19,7 @@ import os
 import pytest
 
 
-class TestWAL:
+class WALTester:
     def __init__(self, path, name, mode):
         """Create a random or zero file resembling a valid WAL, bigger than block size, with a valid header."""
         self.path = os.path.join(path, name)
@@ -123,7 +123,7 @@ class CompressionCase(PGHoardTestCase):
         assert self.compressor.get_event_filetype(event) == "basebackup"
 
     def test_write_file(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000C", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000C", "random")
         with open(ifile.path, "rb") as input_obj, io.BytesIO() as output_obj:
             orig_len, compr_len = rohmufile.write_file(
                 input_obj=input_obj,
@@ -136,7 +136,7 @@ class CompressionCase(PGHoardTestCase):
             assert orig_len == ifile.size
 
     def test_compress_to_file_wal(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000C", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000C", "random")
         self._test_compress_to_file("xlog", ifile.size, ifile.path, ifile.path_partial)
 
     def test_compress_to_file_history(self):
@@ -171,7 +171,7 @@ class CompressionCase(PGHoardTestCase):
             assert transfer_event[key] == value
 
     def test_compress_to_memory(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000C", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000C", "random")
         self.compression_queue.put({
             "compress_to_memory": True,
             "delete_file_after_compression": False,
@@ -200,7 +200,7 @@ class CompressionCase(PGHoardTestCase):
         assert result == ifile.contents
 
     def test_compress_encrypt_to_memory(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000C", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000C", "random")
         self.compressor.config["backup_sites"][self.test_site]["encryption_key_id"] = "testkey"
         event = {
             "compress_to_memory": True,
@@ -228,7 +228,7 @@ class CompressionCase(PGHoardTestCase):
             assert transfer_event[key] == value
 
     def test_archive_command_compression(self):
-        zero = TestWAL(self.incoming_path, "00000001000000000000000D", "zero")
+        zero = WALTester(self.incoming_path, "00000001000000000000000D", "zero")
         callback_queue = Queue()
         event = {
             "callback_queue": callback_queue,
@@ -258,7 +258,7 @@ class CompressionCase(PGHoardTestCase):
         assert self.decompress(transfer_event["blob"]) == zero.contents
 
     def test_decompression_event(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000A", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000A", "random")
         callback_queue = Queue()
         local_filepath = os.path.join(self.temp_dir, "00000001000000000000000A")
         self.compression_queue.put({
@@ -283,7 +283,7 @@ class CompressionCase(PGHoardTestCase):
         assert fdata == ifile.contents
 
     def test_decompression_decrypt_event(self):
-        ifile = TestWAL(self.incoming_path, "00000001000000000000000E", "random")
+        ifile = WALTester(self.incoming_path, "00000001000000000000000E", "random")
         output_obj = io.BytesIO()
         with open(ifile.path, "rb") as input_obj:
             rohmufile.write_file(
@@ -319,7 +319,7 @@ class CompressionCase(PGHoardTestCase):
         assert fdata == ifile.contents
 
     def test_compress_decompress_fileobj(self, tmpdir):
-        plaintext = TestWAL(self.incoming_path, "00000001000000000000000E", "random").contents
+        plaintext = WALTester(self.incoming_path, "00000001000000000000000E", "random").contents
         output_file = tmpdir.join("data.out").strpath
         with open(output_file, "w+b") as plain_fp:
             cmp_fp = compressor.CompressionFile(plain_fp, self.algorithm)


### PR DESCRIPTION
Also adds a missing build-dep-fed azure dependency.

test/test_basebackup.py::TestPG
  cannot collect test class 'TestPG' because it has a __init__ constructor

test/test_compressor.py::TestWAL
  cannot collect test class 'TestWAL' because it has a __init__ constructor