### PR TITLE
pghoard: Only handle MOVE events when handling WAL events

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -352,7 +352,8 @@ class PGHoard:
                     "delete_file_after_compression": True,
                     "full_path": full_path,
                     "site": site,
-                    "type": "CLOSE_WRITE",
+                    "src_path": "{}.partial",
+                    "type": "MOVE",
                 }
                 self.log.debug("Found: %r when starting up, adding to compression queue", compression_event)
                 self.compression_queue.put(compression_event)

--- a/pghoard/walreceiver.py
+++ b/pghoard/walreceiver.py
@@ -129,13 +129,14 @@ class WALReceiver(Thread):
         self.callbacks[self.latest_wal_start] = callback_queue
 
         compression_event = {
-            "type": "CLOSE_WRITE",
+            "type": "MOVE",
             "callback_queue": callback_queue,
             "compress_to_memory": True,
             "delete_file_after_compression": False,
             "input_data": wal_data,
             "full_path": self.latest_wal,
             "site": self.site,
+            "src_path": "{}.partial".format(self.latest_wal),
         }
         self.latest_wal = None
         self.compression_queue.put(compression_event)

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -412,12 +412,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             compress_to_memory = True
         compression_event = {
-            "type": "CLOSE_WRITE",
+            "type": "MOVE",
             "callback_queue": callback_queue,
             "compress_to_memory": compress_to_memory,
             "delete_file_after_compression": False,
             "full_path": xlog_path,
             "site": site,
+            "src_path": "{}.partial".format(xlog_path),
         }
         self.server.compression_queue.put(compression_event)
         try:

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -95,10 +95,6 @@ class CompressionCase(PGHoardTestCase):
         # Rename from non-partial suffix is not recognized
         event["src_path"] += "xyz"
         assert self.compressor.get_event_filetype(event) is None
-        # "CLOSE_WRITE" doesn't consider src_path
-        del event["src_path"]
-        event["type"] = "CLOSE_WRITE"
-        assert self.compressor.get_event_filetype(event) == "xlog"
         # other event types are ignored
         event["type"] = "NAKKI"
         assert self.compressor.get_event_filetype(event) is None
@@ -236,7 +232,7 @@ class CompressionCase(PGHoardTestCase):
             "delete_file_after_compression": False,
             "full_path": zero.path,
             "src_path": zero.path_partial,
-            "type": "CLOSE_WRITE",
+            "type": "MOVE",
         }
         transfer_event = self.compression_queue.put(event)
         transfer_event = self.transfer_queue.get(timeout=5.0)


### PR DESCRIPTION
Also update tests and internal signaling to use only MOVE
events for WAL files.