### PR TITLE
basebackup: use pg_start_backup with fast flag, forcing a checkpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,6 @@ pylint: $(generated)
 	$(PYTHON) -m pylint.lint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
 
 flake8: $(generated)
-	$(PYTHON) -m flake8 --max-line-len=125 $(PYTHON_SOURCE_DIRS)
+	$(PYTHON) -m flake8 --ignore=E722 --max-line-len=125 $(PYTHON_SOURCE_DIRS)
 
 .PHONY: rpm

--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -538,7 +538,7 @@ class PGBaseBackup(Thread):
 
             if self.pg_version_server >= 90600:
                 # We'll always use the the non-exclusive backup mode on 9.6 and newer
-                cursor.execute("SELECT pg_start_backup(%s, false, false)", [BASEBACKUP_NAME])
+                cursor.execute("SELECT pg_start_backup(%s, true, false)", [BASEBACKUP_NAME])
                 backup_label = None
                 backup_mode = "non-exclusive"
             else:
@@ -717,7 +717,7 @@ class PGBaseBackup(Thread):
         # timestamp after pg_stop_backup() was called.
         backup_end_name = "pghoard_end_of_backup"
         if backup_mode == "non-exclusive":
-            cursor.execute("SELECT pg_start_backup(%s, false, false)", [backup_end_name])
+            cursor.execute("SELECT pg_start_backup(%s, true, false)", [backup_end_name])
             cursor.execute("SELECT pg_stop_backup(false)")
         elif backup_mode == "pgespresso":
             cursor.execute("SELECT pgespresso_start_backup(%s, false)", [backup_end_name])


### PR DESCRIPTION
We've seen a few cases where a checkpoint doesn't come along and
we have to wait for extended periods of time. Checkpointing at
backup time (i.e. once a day or so) should be fine.