### PR TITLE
backup sites: add a new configuration option `prefix`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ pghoard X.X.X (unreleased)
 * Support for PostgreSQL 10.1+
 * Use fast checkpoints by default to make the start of backups faster.  Slow
   progress at the beginning of the backup has a tendency to confuse people.
+* Allow overriding the name of the folder for a site's backups by using a
+  new site-level configuration option `prefix`.  Previously backups were
+  always stored in a folder named after the site, optionally prefixed by an
+  undocumented top-level configuration option `path_prefix` which is now
+  deprecated.
 
 
 pghoard 1.6.0 (2017-10-12)

--- a/README.rst
+++ b/README.rst
@@ -638,6 +638,11 @@ This is used when the ``local-tar`` ``basebackup_mode`` is used.  The data
 directory must point to PostgreSQL's ``$PGDATA`` and must be readable by the
 ``pghoard`` daemon.
 
+``prefix`` (default: site name)
+
+Path prefix to use for all backups related to this site.  Defaults to the
+name of the site.
+
 
 Alert files
 ===========

--- a/pghoard/archive_cleanup.py
+++ b/pghoard/archive_cleanup.py
@@ -28,14 +28,13 @@ class ArchiveCleanup:
         storage_config = common.get_object_storage_config(self.config, self.site)
         self.storage = get_transfer(storage_config)
 
-    def storage_path(self, name):
-        return os.path.join(self.config["path_prefix"], self.site, name)
-
     def archive_cleanup(self):
-        basebackups = self.storage.list_path(self.storage_path("basebackup"))
+        basebackup_path = os.path.join(self.backup_site["prefix"], "basebackup")
+        xlog_path = os.path.join(self.backup_site["prefix"], "xlog")
+        basebackups = self.storage.list_path(basebackup_path)
         first_required_wal = min(bb["metadata"]["start-wal-segment"] for bb in basebackups)
         self.log.info("First required WAL segment is %r", first_required_wal)
-        for object_info in self.storage.list_iter(self.storage_path("xlog"), with_metadata=False):
+        for object_info in self.storage.list_iter(xlog_path, with_metadata=False):
             object_name = object_info["name"]
             segment = os.path.basename(object_name)
             if segment < first_required_wal:

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -31,13 +31,11 @@ class CompressorThread(Thread):
         if filetype == "basebackup":
             rest, _ = os.path.split(original_path)
             rest, backupname = os.path.split(rest)
-            folder_for_type = "basebackup"
+            object_path = os.path.join("basebackup", backupname)
         else:
-            backupname = os.path.basename(original_path)
-            folder_for_type = "xlog"
+            object_path = os.path.join("xlog", os.path.basename(original_path))
 
-        cfp = os.path.join(self.config["backup_location"], self.config["path_prefix"],
-                           site, folder_for_type, backupname)
+        cfp = os.path.join(self.config["backup_location"], self.config["backup_sites"][site]["prefix"], object_path)
         self.log.debug("compressed_file_path for %r is %r", original_path, cfp)
         return cfp
 

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -44,7 +44,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
     config.setdefault("json_state_file_path", "/var/lib/pghoard/pghoard_state.json")
     config.setdefault("maintenance_mode_file", "/var/lib/pghoard/maintenance_mode_file")
     config.setdefault("log_level", "INFO")
-    config.setdefault("path_prefix", "")
+    config.setdefault("path_prefix", "")  # deprecated, used in the default path for sites
     config.setdefault("upload_retries_warning_limit", 3)
 
     # default to cpu_count + 1 compression threads
@@ -81,6 +81,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
                                "pipe" if site_config.get("stream_compression") else "basic")
         site_config.setdefault("encryption_key_id", None)
         site_config.setdefault("object_storage", None)
+        site_config.setdefault("prefix", os.path.join(config["path_prefix"], site_name))
 
         # NOTE: pg_data_directory doesn't have a default value
         data_dir = site_config.get("pg_data_directory")

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -71,10 +71,7 @@ class TransferAgent(Thread):
             name = os.path.join(name_parts[-2], name_parts[-1])
         else:
             name = name_parts[-1]
-        return os.path.join(file_to_transfer["path_prefix"],
-                            file_to_transfer["site"],
-                            file_to_transfer["filetype"],
-                            name)
+        return os.path.join(file_to_transfer["prefix"], file_to_transfer["filetype"], name)
 
     def transmit_statsd_metrics(self):
         """
@@ -108,10 +105,13 @@ class TransferAgent(Thread):
                 continue
             if file_to_transfer["type"] == "QUIT":
                 break
+
+            site = file_to_transfer["site"]
+            filetype = file_to_transfer["filetype"]
             self.log.debug("Starting to %r %r, size: %r",
                            file_to_transfer["type"], file_to_transfer["local_path"],
                            file_to_transfer.get("file_size", "unknown"))
-            file_to_transfer.setdefault("path_prefix", self.config["path_prefix"])
+            file_to_transfer.setdefault("prefix", self.config["backup_sites"][site]["prefix"])
             start_time = time.time()
             key = self.form_key_path(file_to_transfer)
             oper = file_to_transfer["type"].lower()
@@ -119,8 +119,6 @@ class TransferAgent(Thread):
             if oper_func is None:
                 self.log.warning("Invalid operation %r", file_to_transfer["type"])
                 continue
-            site = file_to_transfer["site"]
-            filetype = file_to_transfer["filetype"]
 
             result = oper_func(site, key, file_to_transfer)
 

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -162,7 +162,7 @@ LABEL: pg_basebackup base backup
 
         storage_config = common.get_object_storage_config(pghoard.config, pghoard.test_site)
         storage = get_transfer(storage_config)
-        backups = storage.list_path(os.path.join(pghoard.config["path_prefix"], pghoard.test_site, "basebackup"))
+        backups = storage.list_path(os.path.join(pghoard.config["backup_sites"][pghoard.test_site]["prefix"], "basebackup"))
         for backup in backups:
             assert "start-wal-segment" in backup["metadata"]
             assert "start-time" in backup["metadata"]


### PR DESCRIPTION
This allows overriding the path where a site's backups are stored:
previously we always used the name of the site for this, optionally
prefixed by an undocumented top-level `path_prefix` key.