### PR TITLE
Update archive_synce --no-verify help message

### DIFF
--- a/pghoard/archive_sync.py
+++ b/pghoard/archive_sync.py
@@ -177,7 +177,7 @@ class ArchiveSync:
                             version=version.__version__)
         parser.add_argument("--site", help="pghoard site", required=False)
         parser.add_argument("--config", help="pghoard config file", default=os.environ.get("PGHOARD_CONFIG"))
-        parser.add_argument("--no-verify", help="verify archive integrity", action="store_false")
+        parser.add_argument("--no-verify", help="do not verify archive integrity", action="store_false")
         parser.add_argument("--create-new-backup-on-failure", help="request a new basebackup if verification fails",
                             action="store_true", default=False)
         args = parser.parse_args(args)


### PR DESCRIPTION
Went to use this command today and the help text seemed to contradict the option in my mind... I think this is clearer and it matches the `--no-verify` flag's intent.