### PR TITLE
s3: switch to using botocore from boto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 
 install:
-  - "pip install astroid==1.5.2 boto cryptography flake8 httplib2 mock psycopg2 pylint==1.7.4 pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
+  - "pip install astroid==1.5.2 botocore cryptography flake8 httplib2 mock psycopg2 pylint==1.7.4 pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
 
 script:
   - "make pylint"

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-dep-fed:
 	sudo dnf -y install \
 		golang \
 		postgresql-server \
-		python3-boto python3-cryptography python3-dateutil python3-devel \
+		python3-botocore python3-cryptography python3-dateutil python3-devel \
 		python3-flake8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests python3-snappy \
 		python3-azure-storage \

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ pghoard X.X.X (unreleased)
   errors now).  Total WAL segment storage size savings is reported after
   cleanup.  There is a 'dry run' mode available now to estimate cleanup
   effect before deleting actual items.
+* Use botocore rather than boto for interfacing with S3. Botocore is the
+  underlying and maintained library under the newer boto3 SDK.
 
 pghoard 1.6.0 (2017-10-12)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ The following Python modules are required:
 Optional requirements include:
 
 * azure_ for Microsoft Azure object storage
-* boto_ for AWS S3 (or Ceph-S3) object storage
+* botocore_ for AWS S3 (or Ceph-S3) object storage
 * google-api-client_ for Google Cloud object storage
 * cryptography_ for backup encryption and decryption (version 0.8 or newer required)
 * snappy_ for Snappy compression and decompression
@@ -97,7 +97,7 @@ Optional requirements include:
 * swiftclient_ for OpenStack Swift object storage
 
 .. _`azure`: https://github.com/Azure/azure-sdk-for-python
-.. _`boto`: https://github.com/boto/boto
+.. _`botocore`: https://github.com/boto/botocore
 .. _`google-api-client`: https://github.com/google/google-api-python-client
 .. _`cryptography`: https://cryptography.io/
 .. _`snappy`: https://github.com/andrix/python-snappy

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -6,7 +6,7 @@ Summary:        PostgreSQL streaming backup service
 License:        ASL 2.0
 Source0:        pghoard-rpm-src.tar
 Requires:       postgresql-server, systemd
-Requires:       python3-boto, python3-cryptography >= 0.8, python3-dateutil
+Requires:       python3-botocore, python3-cryptography >= 0.8, python3-dateutil
 Requires:       python3-psycopg2, python3-requests, python3-snappy
 Conflicts:      pgespresso92 < 1.2, pgespresso93 < 1.2, pgespresso94 < 1.2, pgespresso95 < 1.2
 BuildRequires:  python3-flake8, python3-pytest, python3-pylint, python3-devel, golang

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -73,7 +73,7 @@ class S3Transfer(BaseTransfer):
         self.log.debug("S3Transfer initialized")
 
     def get_metadata_for_key(self, key):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         return self._metadata_for_key(key)
 
     def _metadata_for_key(self, key):
@@ -89,13 +89,13 @@ class S3Transfer(BaseTransfer):
         return response["Metadata"]
 
     def delete_key(self, key):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", key)
         self._metadata_for_key(key)  # check that key exists
         self.s3_client.delete_object(Bucket=self.bucket_name, Key=key)
 
     def list_iter(self, key, *, with_metadata=True):
-        path = self.format_key_for_backend(key, trailing_slash=True)
+        path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=True)
         self.log.debug("Listing path %r", path)
         continuation_token = None
         while True:
@@ -125,7 +125,7 @@ class S3Transfer(BaseTransfer):
                 break
 
     def _get_object_stream(self, key):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         try:
             response = self.s3_client.get_object(
                 Bucket=self.bucket_name,
@@ -170,7 +170,7 @@ class S3Transfer(BaseTransfer):
         return data, metadata
 
     def store_file_from_memory(self, key, memstring, metadata=None):
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
         args = {
             "Bucket": self.bucket_name,
             "Body": memstring,
@@ -190,7 +190,7 @@ class S3Transfer(BaseTransfer):
                 self.store_file_from_memory(key, data, metadata)
             return
 
-        key = self.format_key_for_backend(key)
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
 
         start_of_multipart_upload = time.monotonic()
         chunks = math.ceil(size / self.multipart_chunk_size)


### PR DESCRIPTION
Use botocore rather than boto for interfacing with S3. Botocore is the undelying library under boto3 and is actively maintained.

E.g. at the time of writing, botocore support the new eu-west-3 region, while boto is still lacking definition for it.