### PR TITLE
travis: pin pylint to version 1.7.4 and astroid 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 
 install:
-  - "pip install boto cryptography flake8 httplib2 mock psycopg2 pylint pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
+  - "pip install astroid==1.5.2 boto cryptography flake8 httplib2 mock psycopg2 pylint==1.7.4 pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
 
 script:
   - "make pylint"


### PR DESCRIPTION
Pylint 1.8.1 has a bug https://github.com/PyCQA/pylint/issues/1773 that breaks with bare exception re-raises. Pin to a specific working version until the fixed pylint is available on PyPI.