### PR TITLE
webserver: Reduce logging when prefetching WAL files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 
 install:
-  - "pip install astroid==1.5.2 botocore cryptography flake8 httplib2 mock psycopg2 pylint==1.7.4 pytest python-dateutil python-snappy python-systemd requests azure azure-storage"
+  - "pip install astroid==1.5.2 botocore cryptography flake8 httplib2 mock psycopg2 pylint==1.7.4 pytest python-dateutil python-snappy python-systemd requests azure-storage"
 
 script:
   - "make pylint"

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -270,7 +270,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                         wal.verify_wal(wal_name=prefetch_name, filepath=xlog_path)
                         continue
                     except ValueError as e:
-                        self.server.log.warning("(Prefetch) File %s already exists but is invalid: %r", xlog_path, e)
+                        self.server.log.debug("(Prefetch) File %s already exists but is invalid: %r", xlog_path, e)
                 names.append(prefetch_name)
 
         for obname in names:


### PR DESCRIPTION
Pre-existing WAL files whose contents don't match the name of the file
is a normal condition that can happen very often so don't log warning
every time such situation occurs. Having a lot of bogus warnings makes
it more difficult to spot real errors.