### PR TITLE
webserver: Fix handling of timed out downloads

### DIFF
--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -211,9 +211,10 @@ class TransferAgent(Thread):
 
     def handle_download(self, site, key, file_to_transfer):
         try:
-            file_size = self.fetch_manager.fetch_file(site, key, file_to_transfer["target_path"])
+            path = file_to_transfer["target_path"]
+            file_size = self.fetch_manager.fetch_file(site, key, path)
             file_to_transfer["file_size"] = file_size
-            return {"success": True, "opaque": file_to_transfer.get("opaque")}
+            return {"success": True, "opaque": file_to_transfer.get("opaque"), "target_path": path}
         except FileNotFoundFromStorageError as ex:
             self.log.warning("%r not found from storage", key)
             return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}


### PR DESCRIPTION
If a download has taken longer than it should, a new download operation
for the same file is started. Previously this overwrote the expected
name of the temporary file that shall be created by the download. This
caused problems if the earlier download did eventually finish and it
also finished before the newly scheduled download. The result handler
was called for the first download as well but instead of using the
original temp file name it used the second download's temp file name,
which was still in progress and the file was empty.

The operation was retried for 30 seconds and future downloads might
have succeeded but depending on timing conditions there could've been
multiple failures and the download failed permanently, causing WAL
restoration to fail.

Currently missing unittest for exercising the fix because there's no
easy way to mock behavior in the remote process and more isolated
test cannot be done without major refactoring.